### PR TITLE
add jwks background refresh and bootstrap_lease_ttl (phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Legion::Crypt
 
+## [1.5.3] - 2026-04-06
+
+### Added
+- `JwksClient.prefetch!(url)` — fire-and-forget JWKS key fetch in background thread
+- `JwksClient.start_background_refresh!(url, interval:)` — `Concurrent::TimerTask` for hourly key refresh
+- `JwksClient.stop_background_refresh!` — stops background refresh timer task
+- `bootstrap_lease_ttl: 300` in vault defaults (5-minute TTL for bootstrap credentials)
+
+### Changed
+- `JwksClient.clear_cache` now also stops any running background refresh task
+
 ## [1.5.2] - 2026-04-03
 
 ### Fixed

--- a/legion-crypt.gemspec
+++ b/legion-crypt.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
+  spec.add_dependency 'concurrent-ruby', '~> 1.3'
   spec.add_dependency 'ed25519', '~> 1.3'
   spec.add_dependency 'jwt', '>= 2.7'
   spec.add_dependency 'legion-logging', '>= 1.5.0'

--- a/lib/legion/crypt/jwks_client.rb
+++ b/lib/legion/crypt/jwks_client.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'openssl'
 require 'jwt'
 require 'legion/logging/helper'
+require 'concurrent'
 
 module Legion
   module Crypt
@@ -56,7 +57,33 @@ module Legion
           raise Legion::Crypt::JWT::InvalidTokenError, "signing key not found: #{kid}"
         end
 
+        def prefetch!(jwks_url)
+          Thread.new do
+            fetch_keys(jwks_url)
+          rescue StandardError => e
+            log.debug "JWKS prefetch failed for #{jwks_url}: #{e.message}" if respond_to?(:log)
+          end
+        end
+
+        def start_background_refresh!(jwks_url, interval: CACHE_TTL)
+          stop_background_refresh!
+
+          @refresh_task = Concurrent::TimerTask.new(execution_interval: interval, run_now: false) do
+            fetch_keys(jwks_url)
+          rescue StandardError => e
+            log.debug "JWKS background refresh failed: #{e.message}" if respond_to?(:log)
+          end
+          @refresh_task.execute
+          log.info "JWKS background refresh started (interval=#{interval}s)" if respond_to?(:log)
+        end
+
+        def stop_background_refresh!
+          @refresh_task&.shutdown
+          @refresh_task = nil
+        end
+
         def clear_cache
+          stop_background_refresh!
           @cache_mutex.synchronize { @cache = {} }
           @locks_mutex.synchronize { @locks = {} }
           log.info 'JWKS cache cleared'

--- a/lib/legion/crypt/settings.rb
+++ b/lib/legion/crypt/settings.rb
@@ -72,7 +72,8 @@ module Legion
             service_principal: nil,
             auth_path:         'auth/kerberos/login'
           },
-          clusters:            {}
+          clusters:            {},
+          bootstrap_lease_ttl: 300
         }
       end
     end

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.2'
+    VERSION = '1.5.3'
   end
 end


### PR DESCRIPTION
## Summary

- `JwksClient.prefetch!(url)` — fire-and-forget JWKS key fetch in background thread
- `JwksClient.start_background_refresh!(url, interval:)` — `Concurrent::TimerTask` for hourly key refresh
- `JwksClient.stop_background_refresh!` — stops timer task
- `clear_cache` now also stops background refresh
- `bootstrap_lease_ttl: 300` added to vault defaults (5-minute TTL for bootstrap credentials)

## Dependencies

Part of unified identity Phase 2 — companion PRs:
- **LegionIO**: LegionIO/LegionIO#45 (core identity module)
- **legion-data**: LegionIO/legion-data#25 (identity schema)

## Test plan

- [ ] `bundle exec rspec` passes
- [ ] `bundle exec rubocop -A` passes
- [ ] Verify `JwksClient.prefetch!` does not raise on failure
- [ ] Verify `start_background_refresh!` creates timer task
- [ ] Verify `clear_cache` stops background refresh