### PR TITLE
add JWT.issue_identity_token for wire format phase 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-04-06
+
 ### Added
-- `JWT.issue_identity_token` — convenience method wrapping `JWT.issue` with identity claims from `Identity::Process` (Wire Format Phase 3)
+- `JWT.issue_identity_token` — convenience method wrapping `JWT.issue` with identity claims from `Identity::Process` (Wire Format Phase 3); accepts `issuer:` kwarg (defaults to `'legion'`) passed through to `JWT.issue`; normalizes and rejects conflicting string-keyed extra claims before merging
 
 ## [1.5.3] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion::Crypt
 
+## [Unreleased]
+
+### Added
+- `JWT.issue_identity_token` — convenience method wrapping `JWT.issue` with identity claims from `Identity::Process` (Wire Format Phase 3)
+
 ## [1.5.3] - 2026-04-06
 
 ### Added

--- a/lib/legion/crypt/jwt.rb
+++ b/lib/legion/crypt/jwt.rb
@@ -36,6 +36,26 @@ module Legion
         raise
       end
 
+      def self.issue_identity_token(signing_key:, extra_claims: {}, algorithm: 'HS256', ttl: 3600)
+        unless defined?(Legion::Identity::Process) && Legion::Identity::Process.resolved?
+          raise ArgumentError,
+                'Identity::Process not resolved'
+        end
+
+        identity = Legion::Identity::Process.identity_hash
+        identity_fields = {
+          sub:            identity[:canonical_name],
+          principal_id:   identity[:id],
+          canonical_name: identity[:canonical_name],
+          kind:           identity[:kind].to_s,
+          mode:           identity[:mode].to_s,
+          groups:         (identity[:groups] || [])[0, 50]
+        }
+        payload = extra_claims.merge(identity_fields)
+
+        issue(payload, signing_key: signing_key, algorithm: algorithm, ttl: ttl)
+      end
+
       def self.verify(token, verification_key:, **opts)
         algorithm = opts.fetch(:algorithm, 'HS256')
         verify_expiration = opts.fetch(:verify_expiration, true)

--- a/lib/legion/crypt/jwt.rb
+++ b/lib/legion/crypt/jwt.rb
@@ -36,7 +36,7 @@ module Legion
         raise
       end
 
-      def self.issue_identity_token(signing_key:, extra_claims: {}, algorithm: 'HS256', ttl: 3600)
+      def self.issue_identity_token(signing_key:, extra_claims: {}, algorithm: 'HS256', ttl: 3600, issuer: 'legion')
         unless defined?(Legion::Identity::Process) && Legion::Identity::Process.resolved?
           raise ArgumentError,
                 'Identity::Process not resolved'
@@ -51,9 +51,12 @@ module Legion
           mode:           identity[:mode].to_s,
           groups:         (identity[:groups] || [])[0, 50]
         }
-        payload = extra_claims.merge(identity_fields)
+        normalized_extra_claims = symbolize_keys(extra_claims || {}).reject do |key, _value|
+          identity_fields.key?(key)
+        end
+        payload = normalized_extra_claims.merge(identity_fields)
 
-        issue(payload, signing_key: signing_key, algorithm: algorithm, ttl: ttl)
+        issue(payload, signing_key: signing_key, algorithm: algorithm, ttl: ttl, issuer: issuer)
       end
 
       def self.verify(token, verification_key:, **opts)

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.3'
+    VERSION = '1.5.4'
   end
 end

--- a/spec/legion/jwt_spec.rb
+++ b/spec/legion/jwt_spec.rb
@@ -87,6 +87,69 @@ RSpec.describe Legion::Crypt::JWT do
     end
   end
 
+  describe '.issue_identity_token' do
+    let(:identity) do
+      {
+        id:             'identity-123',
+        canonical_name: 'agent@example.com',
+        kind:           :service,
+        mode:           :automated,
+        groups:         (1..55).map { |i| "group-#{i}" }
+      }
+    end
+    let(:identity_resolved) { true }
+
+    before do
+      stub_const(
+        'Legion::Identity::Process',
+        Module.new do
+          class << self
+            attr_accessor :identity_hash, :resolved
+          end
+
+          def self.resolved?
+            resolved
+          end
+        end
+      )
+
+      Legion::Identity::Process.identity_hash = identity
+      Legion::Identity::Process.resolved = identity_resolved
+    end
+
+    it 'issues a token with immutable identity claims and preserves extra claims' do
+      token = described_class.issue_identity_token(
+        signing_key: signing_key,
+        extra_claims: {
+          sub:    'override-me',
+          groups: %w[override],
+          role:   'worker'
+        },
+        ttl: 120
+      )
+
+      decoded = described_class.decode(token)
+
+      expect(decoded[:sub]).to eq('agent@example.com')
+      expect(decoded[:principal_id]).to eq('identity-123')
+      expect(decoded[:canonical_name]).to eq('agent@example.com')
+      expect(decoded[:kind]).to eq('service')
+      expect(decoded[:mode]).to eq('automated')
+      expect(decoded[:groups]).to eq(identity[:groups].first(50))
+      expect(decoded[:role]).to eq('worker')
+    end
+
+    context 'when identity process is not resolved' do
+      let(:identity_resolved) { false }
+
+      it 'raises an error' do
+        expect do
+          described_class.issue_identity_token(signing_key: signing_key)
+        end.to raise_error(ArgumentError, /Identity::Process not resolved/)
+      end
+    end
+  end
+
   describe '.verify' do
     it 'verifies a valid HS256 token' do
       token = described_class.issue(payload, signing_key: signing_key)

--- a/spec/legion/jwt_spec.rb
+++ b/spec/legion/jwt_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Legion::Crypt::JWT do
   end
 
   describe '.issue_identity_token' do
-    let(:identity) do
+    let(:identity_hash) do
       {
         id:             'identity-123',
         canonical_name: 'agent@example.com',
@@ -113,19 +113,19 @@ RSpec.describe Legion::Crypt::JWT do
         end
       )
 
-      Legion::Identity::Process.identity_hash = identity
+      Legion::Identity::Process.identity_hash = identity_hash
       Legion::Identity::Process.resolved = identity_resolved
     end
 
     it 'issues a token with immutable identity claims and preserves extra claims' do
       token = described_class.issue_identity_token(
-        signing_key: signing_key,
+        signing_key:  signing_key,
         extra_claims: {
           sub:    'override-me',
           groups: %w[override],
           role:   'worker'
         },
-        ttl: 120
+        ttl:          120
       )
 
       decoded = described_class.decode(token)
@@ -135,8 +135,60 @@ RSpec.describe Legion::Crypt::JWT do
       expect(decoded[:canonical_name]).to eq('agent@example.com')
       expect(decoded[:kind]).to eq('service')
       expect(decoded[:mode]).to eq('automated')
-      expect(decoded[:groups]).to eq(identity[:groups].first(50))
+      expect(decoded[:groups]).to eq(identity_hash[:groups].first(50))
       expect(decoded[:role]).to eq('worker')
+    end
+
+    it 'passes issuer kwarg through to JWT.issue' do
+      token = described_class.issue_identity_token(signing_key: signing_key, issuer: 'my-cluster')
+      decoded = described_class.decode(token)
+      expect(decoded[:iss]).to eq('my-cluster')
+    end
+
+    it 'defaults issuer to legion' do
+      token = described_class.issue_identity_token(signing_key: signing_key)
+      decoded = described_class.decode(token)
+      expect(decoded[:iss]).to eq('legion')
+    end
+
+    it 'prevents extra_claims from overriding identity fields via string keys' do
+      token = described_class.issue_identity_token(
+        signing_key:  signing_key,
+        extra_claims: { 'sub' => 'evil', 'canonical_name' => 'forged' }
+      )
+      decoded = described_class.decode(token)
+      expect(decoded[:sub]).to eq('agent@example.com')
+      expect(decoded[:canonical_name]).to eq('agent@example.com')
+    end
+
+    it 'merges non-conflicting extra_claims into token' do
+      token = described_class.issue_identity_token(
+        signing_key:  signing_key,
+        extra_claims: { tenant_id: 'acme', role: 'agent' }
+      )
+      decoded = described_class.decode(token)
+      expect(decoded[:tenant_id]).to eq('acme')
+      expect(decoded[:role]).to eq('agent')
+    end
+
+    it 'caps groups at 50 entries' do
+      token = described_class.issue_identity_token(signing_key: signing_key)
+      decoded = described_class.decode(token)
+      expect(decoded[:groups].length).to eq(50)
+    end
+
+    it 'handles nil groups gracefully' do
+      Legion::Identity::Process.identity_hash = identity_hash.merge(groups: nil)
+      token = described_class.issue_identity_token(signing_key: signing_key)
+      decoded = described_class.decode(token)
+      expect(decoded[:groups]).to eq([])
+    end
+
+    it 'raises ArgumentError when Identity::Process is not defined' do
+      hide_const('Legion::Identity::Process')
+      expect do
+        described_class.issue_identity_token(signing_key: signing_key)
+      end.to raise_error(ArgumentError, /Identity::Process not resolved/)
     end
 
     context 'when identity process is not resolved' do


### PR DESCRIPTION
## Summary
- New `JWT.issue_identity_token(signing_key:, extra_claims: {}, algorithm:, ttl:)` wraps `JWT.issue` with identity claims from `Identity::Process`
- Claims: `sub`, `principal_id`, `canonical_name`, `kind`, `mode`, `groups` (capped at 50)
- Identity fields are immutable — `extra_claims.merge(identity_fields)` ensures callers cannot override them
- Raises `ArgumentError` if `Identity::Process` not resolved
- Added specs for `issue_identity_token` covering identity claim precedence, group cap, and unresolved identity error

## Design Doc
- `docs/plans/2026-04-06-wire-format-identity-design.md` §4

## Cross-repo PRs (Wire Format Phase 3 Group 1)
- LegionIO: Identity::Process source: prerequisite
- legion-transport: AMQP identity headers
- legion-llm: Profile.derive update

## Test plan
- [x] 516 examples, 0 failures
- [x] rubocop clean (1 auto-corrected: kwarg ordering)