### PR TITLE
implement Phase 5 credential scoping — Group 3 (credential swap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.5.5] - 2026-04-07
+
+### Added
+- `RMQ_ROLE_MAP` constant mapping `:agent`/`:infra` → `'legionio-infra'` and `:worker` → `'legionio-worker'` for Vault RabbitMQ role selection (Phase 5 credential scoping)
+- `dynamic_rmq_creds?` helper reads `Settings[:crypt][:vault][:dynamic_rmq_creds]` flag
+- `fetch_bootstrap_rmq_creds` — fetches short-lived bootstrap RabbitMQ credentials from `rabbitmq/creds/legionio-bootstrap` and writes them to `Settings[:transport][:connection]`; gated on `vault_connected? && dynamic_rmq_creds?`; stores `@bootstrap_lease_id` for later revocation; rescue-safe
+- `swap_to_identity_creds(mode:)` — fetches identity-scoped RabbitMQ credentials from the role matching `mode`, registers them with `LeaseManager` for renewal, updates transport settings, calls `Transport::Connection.force_reconnect`, and revokes the bootstrap lease; raises if reconnect fails (before revoking bootstrap)
+- `revoke_bootstrap_lease` — revokes `@bootstrap_lease_id` via `LeaseManager#vault_sys`; non-fatal on failure; idempotent
+- `LeaseManager#register_dynamic_lease` — registers a dynamically-fetched Vault lease into the cache and active lease tracking with mutex, stores `path` for `reissue_lease`, registers settings refs for rotation push-back
+- `LeaseManager#reissue_lease(name)` — performs a full re-read (`logical.read(path)`) at credential rotation time, updates cache + active_leases in mutex, calls `push_to_settings`, triggers `Transport::Connection.force_reconnect` for `:rabbitmq` leases
+- `LeaseManager#vault_logical` and `LeaseManager#vault_sys` — public delegators to the private `logical`/`sys` methods for use by `Crypt` bootstrap/swap operations
+- `dynamic_rmq_creds: false` and `dynamic_pg_creds: false` defaults added to vault settings
+
+### Changed
+- `start_lease_manager` now starts the renewal thread when `dynamic_rmq_creds: true` even if no static leases are configured, ensuring the renewal loop is running before identity-scoped leases are registered post-boot
+
 ## [1.5.4] - 2026-04-06
 
 ### Added

--- a/lib/legion/crypt.rb
+++ b/lib/legion/crypt.rb
@@ -25,6 +25,12 @@ module Legion
     extend Legion::Crypt::VaultCluster
     extend Legion::Crypt::LdapAuth
 
+    RMQ_ROLE_MAP = {
+      agent:  'legionio-infra',
+      worker: 'legionio-worker',
+      infra:  'legionio-infra'
+    }.freeze
+
     class << self
       attr_reader :sessions
 
@@ -97,6 +103,74 @@ module Legion
         settings[:jwt] || Legion::Crypt::Settings.jwt
       end
 
+      def dynamic_rmq_creds?
+        Legion::Settings.dig(:crypt, :vault, :dynamic_rmq_creds) == true
+      end
+
+      def fetch_bootstrap_rmq_creds
+        return unless vault_connected? && dynamic_rmq_creds?
+
+        Legion::Settings.merge_settings('transport', Legion::Transport::Settings.default) if defined?(Legion::Transport::Settings)
+
+        response = LeaseManager.instance.vault_logical.read('rabbitmq/creds/legionio-bootstrap')
+        return unless response&.data
+
+        @bootstrap_lease_id = response.lease_id
+        @bootstrap_lease_expires = Time.now + [response.lease_duration, 300].min
+
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection) || {}
+        conn[:user]     = response.data[:username]
+        conn[:password] = response.data[:password]
+
+        log.info "Bootstrap RMQ credentials acquired (lease: #{@bootstrap_lease_id[0..7]}...)"
+      rescue StandardError => e
+        log.warn "Bootstrap RMQ credential fetch failed: #{e.message}"
+      end
+
+      def swap_to_identity_creds(mode:)
+        return unless vault_connected? && dynamic_rmq_creds?
+        return if mode == :lite
+
+        role = RMQ_ROLE_MAP.fetch(mode, "legionio-#{mode}")
+        response = LeaseManager.instance.vault_logical.read("rabbitmq/creds/#{role}")
+        raise "Failed to fetch identity-scoped RMQ creds for role #{role}" unless response&.data
+
+        LeaseManager.instance.register_dynamic_lease(
+          name:          :rabbitmq,
+          path:          "rabbitmq/creds/#{role}",
+          response:      response,
+          settings_refs: [
+            { path: %i[transport connection user],     key: :username },
+            { path: %i[transport connection password], key: :password }
+          ]
+        )
+
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection) || {}
+        conn[:user]     = response.data[:username]
+        conn[:password] = response.data[:password]
+
+        if defined?(Legion::Transport::Connection)
+          Legion::Transport::Connection.force_reconnect
+          raise 'Transport reconnect failed after credential swap — bootstrap lease NOT revoked' unless Legion::Transport::Connection.session_open?
+
+          log.info "Transport reconnected with identity-scoped creds (role: #{role})"
+        end
+
+        revoke_bootstrap_lease
+      end
+
+      def revoke_bootstrap_lease
+        return unless @bootstrap_lease_id
+
+        LeaseManager.instance.vault_sys.revoke(@bootstrap_lease_id)
+        log.info "Bootstrap RMQ lease revoked (#{@bootstrap_lease_id[0..7]}...)"
+        @bootstrap_lease_id      = nil
+        @bootstrap_lease_expires = nil
+      rescue StandardError => e
+        log.warn "Bootstrap lease revocation failed: #{e.message} — lease will expire naturally"
+        @bootstrap_lease_id = nil
+      end
+
       def vault_connected?
         return true if settings.dig(:vault, :connected) == true
         return true if respond_to?(:connected_clusters) && connected_clusters.any?
@@ -156,8 +230,10 @@ module Legion
 
       def start_lease_manager
         leases = settings.dig(:vault, :leases) || {}
-        return if leases.empty?
-        return unless connected_clusters.any? || settings.dig(:vault, :connected)
+        vault_ok = connected_clusters.any? || settings.dig(:vault, :connected)
+
+        return if leases.empty? && !dynamic_rmq_creds?
+        return unless vault_ok
 
         client = nil
 
@@ -167,15 +243,19 @@ module Legion
         elsif settings.dig(:vault, :connected)
           client = vault_client
         end
+
         lease_manager = Legion::Crypt::LeaseManager.instance
         lease_manager.start(leases, vault_client: client)
         lease_manager.start_renewal_thread
-        fetched = lease_manager.fetched_count
-        defined = leases.size
-        if fetched == defined
-          log.info "LeaseManager: #{fetched} lease(s) initialized"
-        else
-          log.warn "LeaseManager: #{fetched}/#{defined} lease(s) initialized (#{defined - fetched} failed)"
+
+        unless leases.empty?
+          fetched = lease_manager.fetched_count
+          defined = leases.size
+          if fetched == defined
+            log.info "LeaseManager: #{fetched} lease(s) initialized"
+          else
+            log.warn "LeaseManager: #{fetched}/#{defined} lease(s) initialized (#{defined - fetched} failed)"
+          end
         end
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'crypt.start_lease_manager')

--- a/lib/legion/crypt.rb
+++ b/lib/legion/crypt.rb
@@ -125,8 +125,16 @@ module Legion
         settings[:transport] ||= {}
         settings[:transport][:connection] ||= {}
         conn = settings[:transport][:connection]
-        conn[:user]     = response.data[:username]
-        conn[:password] = response.data[:password]
+        username = response.data[:username] || response.data['username']
+        password = response.data[:password] || response.data['password']
+
+        unless username && password
+          log.warn 'Bootstrap RMQ credential fetch returned nil username or password — skipping settings update'
+          return
+        end
+
+        conn[:user]     = username
+        conn[:password] = password
 
         log.info "Bootstrap RMQ credentials acquired (lease: #{@bootstrap_lease_id[0..7]}...)"
       rescue StandardError => e
@@ -155,8 +163,12 @@ module Legion
         settings[:transport] ||= {}
         settings[:transport][:connection] ||= {}
         conn = settings[:transport][:connection]
-        conn[:user]     = response.data[:username]
-        conn[:password] = response.data[:password]
+        username = response.data[:username] || response.data['username']
+        password = response.data[:password] || response.data['password']
+        raise "Identity-scoped RMQ creds for role #{role} missing username or password" unless username && password
+
+        conn[:user]     = username
+        conn[:password] = password
 
         if defined?(Legion::Transport::Connection)
           Legion::Transport::Connection.force_reconnect

--- a/lib/legion/crypt.rb
+++ b/lib/legion/crypt.rb
@@ -115,10 +115,16 @@ module Legion
         response = LeaseManager.instance.vault_logical.read('rabbitmq/creds/legionio-bootstrap')
         return unless response&.data
 
-        @bootstrap_lease_id = response.lease_id
-        @bootstrap_lease_expires = Time.now + [response.lease_duration, 300].min
+        bootstrap_lease_ttl = Legion::Settings.dig(:crypt, :vault, :bootstrap_lease_ttl).to_i
+        bootstrap_lease_ttl = 300 if bootstrap_lease_ttl <= 0
 
-        conn = Legion::Settings.loader.settings.dig(:transport, :connection) || {}
+        @bootstrap_lease_id = response.lease_id
+        @bootstrap_lease_expires = Time.now + [response.lease_duration, bootstrap_lease_ttl].min
+
+        settings = Legion::Settings.loader.settings
+        settings[:transport] ||= {}
+        settings[:transport][:connection] ||= {}
+        conn = settings[:transport][:connection]
         conn[:user]     = response.data[:username]
         conn[:password] = response.data[:password]
 
@@ -145,7 +151,10 @@ module Legion
           ]
         )
 
-        conn = Legion::Settings.loader.settings.dig(:transport, :connection) || {}
+        settings = Legion::Settings.loader.settings
+        settings[:transport] ||= {}
+        settings[:transport][:connection] ||= {}
+        conn = settings[:transport][:connection]
         conn[:user]     = response.data[:username]
         conn[:password] = response.data[:password]
 
@@ -168,7 +177,8 @@ module Legion
         @bootstrap_lease_expires = nil
       rescue StandardError => e
         log.warn "Bootstrap lease revocation failed: #{e.message} — lease will expire naturally"
-        @bootstrap_lease_id = nil
+        @bootstrap_lease_id      = nil
+        @bootstrap_lease_expires = nil
       end
 
       def vault_connected?

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -108,6 +108,8 @@ module Legion
       end
 
       def register_dynamic_lease(name:, path:, response:, settings_refs:)
+        register_at_exit_hook
+
         @state_mutex.synchronize do
           @lease_cache[name] = response.data || {}
           @active_leases[name] = {
@@ -299,10 +301,14 @@ module Legion
         leases.each do |name|
           lease = @state_mutex.synchronize { @active_leases[name]&.dup }
           next unless lease
-          next unless lease[:renewable]
           next unless approaching_expiry?(lease)
 
-          renew_lease(name, lease)
+          if lease[:renewable]
+            renew_lease(name, lease)
+          elsif lease[:path]
+            log.info("LeaseManager: lease '#{name}' is non-renewable and approaching expiry — re-issuing")
+            reissue_lease(name)
+          end
         end
       end
 
@@ -326,6 +332,7 @@ module Legion
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'crypt.lease_manager.renew_lease', lease_name: name)
         log.warn("LeaseManager: failed to renew lease '#{name}': #{e.message}")
+        reissue_lease(name) if lease[:path]
       end
 
       def lease_valid?(name)

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -133,11 +133,16 @@ module Legion
         return unless response&.data
 
         @state_mutex.synchronize do
+          active_lease = @active_leases[name]
+          next unless active_lease
+
           @lease_cache[name] = response.data
-          @active_leases[name].merge!(
-            lease_id:   response.lease_id,
-            expires_at: Time.now + (response.lease_duration || 0),
-            fetched_at: Time.now
+          active_lease.merge!(
+            lease_id:       response.lease_id,
+            lease_duration: response.lease_duration,
+            expires_at:     Time.now + (response.lease_duration || 0),
+            fetched_at:     Time.now,
+            renewable:      response.renewable?
           )
         end
         push_to_settings(name)

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -97,6 +97,60 @@ module Legion
         log.info("Lease '#{name}' rotated — updated #{refs.size} settings reference(s)")
       end
 
+      # Public Vault client accessors used by Crypt for bootstrap/swap operations.
+      # Delegates to the configured vault_client or falls back to ::Vault.
+      def vault_logical
+        logical
+      end
+
+      def vault_sys
+        sys
+      end
+
+      def register_dynamic_lease(name:, path:, response:, settings_refs:)
+        @state_mutex.synchronize do
+          @lease_cache[name] = response.data || {}
+          @active_leases[name] = {
+            lease_id:       response.lease_id,
+            lease_duration: response.lease_duration,
+            expires_at:     Time.now + (response.lease_duration || 0),
+            fetched_at:     Time.now,
+            renewable:      response.renewable?,
+            path:           path
+          }
+        end
+        settings_refs.each do |ref|
+          register_ref(name, ref[:key], ref[:path])
+        end
+        log.info("LeaseManager: registered dynamic lease '#{name}' (path: #{path})")
+      end
+
+      def reissue_lease(name)
+        lease = @state_mutex.synchronize { @active_leases[name]&.dup }
+        return unless lease && lease[:path]
+
+        response = logical.read(lease[:path])
+        return unless response&.data
+
+        @state_mutex.synchronize do
+          @lease_cache[name] = response.data
+          @active_leases[name].merge!(
+            lease_id:   response.lease_id,
+            expires_at: Time.now + (response.lease_duration || 0),
+            fetched_at: Time.now
+          )
+        end
+        push_to_settings(name)
+
+        return unless name == :rabbitmq && defined?(Legion::Transport::Connection)
+
+        Legion::Transport::Connection.force_reconnect
+        log.info("LeaseManager: reissued lease '#{name}' and triggered transport reconnect")
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'crypt.lease_manager.reissue_lease', lease_name: name)
+        log.warn("LeaseManager: failed to reissue lease '#{name}': #{e.message}")
+      end
+
       def start_renewal_thread
         @state_mutex.synchronize do
           return if @renewal_thread&.alive?

--- a/lib/legion/crypt/settings.rb
+++ b/lib/legion/crypt/settings.rb
@@ -73,7 +73,9 @@ module Legion
             auth_path:         'auth/kerberos/login'
           },
           clusters:            {},
-          bootstrap_lease_ttl: 300
+          bootstrap_lease_ttl: 300,
+          dynamic_rmq_creds:   false,
+          dynamic_pg_creds:    false
         }
       end
     end

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.4'
+    VERSION = '1.5.5'
   end
 end

--- a/spec/legion/crypt/credential_scoping_spec.rb
+++ b/spec/legion/crypt/credential_scoping_spec.rb
@@ -11,10 +11,26 @@ RSpec.describe Legion::Crypt do
            renewable?:     false)
   end
 
+  let(:vault_response_string_keys) do
+    double('Vault::Secret',
+           data:           { 'username' => 'bootstrap_user_str', 'password' => 'bootstrap_pass_str' },
+           lease_id:       'rabbitmq/creds/legionio-bootstrap/str123',
+           lease_duration: 300,
+           renewable?:     false)
+  end
+
   let(:identity_response) do
     double('Vault::Secret',
            data:           { username: 'identity_user', password: 'identity_pass' },
            lease_id:       'rabbitmq/creds/legionio-infra/def456',
+           lease_duration: 604_800,
+           renewable?:     true)
+  end
+
+  let(:identity_response_string_keys) do
+    double('Vault::Secret',
+           data:           { 'username' => 'identity_user_str', 'password' => 'identity_pass_str' },
+           lease_id:       'rabbitmq/creds/legionio-infra/str456',
            lease_duration: 604_800,
            renewable?:     true)
   end
@@ -115,6 +131,28 @@ RSpec.describe Legion::Crypt do
       described_class.fetch_bootstrap_rmq_creds
       conn = Legion::Settings.loader.settings.dig(:transport, :connection)
       expect(conn[:password]).to eq('bootstrap_pass')
+    end
+
+    context 'when Vault returns string-keyed data' do
+      before { allow(logical_double).to receive(:read).and_return(vault_response_string_keys) }
+
+      it 'writes username to transport connection settings from string key' do
+        described_class.fetch_bootstrap_rmq_creds
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+        expect(conn[:user]).to eq('bootstrap_user_str')
+      end
+
+      it 'writes password to transport connection settings from string key' do
+        described_class.fetch_bootstrap_rmq_creds
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+        expect(conn[:password]).to eq('bootstrap_pass_str')
+      end
+
+      it 'stores the bootstrap lease_id from string-keyed response' do
+        described_class.fetch_bootstrap_rmq_creds
+        expect(described_class.instance_variable_get(:@bootstrap_lease_id))
+          .to eq('rabbitmq/creds/legionio-bootstrap/str123')
+      end
     end
 
     context 'when vault is not connected' do
@@ -275,6 +313,28 @@ RSpec.describe Legion::Crypt do
         described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/xyz789')
         expect(sys_double).to receive(:revoke).with('boot/lease/xyz789')
         described_class.swap_to_identity_creds(mode: :agent)
+      end
+    end
+
+    context 'when Vault returns string-keyed identity data' do
+      before do
+        stub_const('Legion::Transport::Connection', transport_connection_double)
+        allow(transport_connection_double).to receive(:force_reconnect)
+        allow(Legion::Crypt::LeaseManager.instance).to receive(:register_dynamic_lease)
+        allow(logical_double).to receive(:read).with('rabbitmq/creds/legionio-infra')
+                                               .and_return(identity_response_string_keys)
+      end
+
+      it 'writes identity username to transport connection settings from string key' do
+        described_class.swap_to_identity_creds(mode: :agent)
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+        expect(conn[:user]).to eq('identity_user_str')
+      end
+
+      it 'writes identity password to transport connection settings from string key' do
+        described_class.swap_to_identity_creds(mode: :agent)
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+        expect(conn[:password]).to eq('identity_pass_str')
       end
     end
 

--- a/spec/legion/crypt/credential_scoping_spec.rb
+++ b/spec/legion/crypt/credential_scoping_spec.rb
@@ -351,6 +351,14 @@ RSpec.describe Legion::Crypt do
       expect(described_class.instance_variable_get(:@bootstrap_lease_id)).to be_nil
     end
 
+    it 'clears @bootstrap_lease_expires even when revocation fails' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
+      described_class.instance_variable_set(:@bootstrap_lease_expires, Time.now + 100)
+      allow(sys_double).to receive(:revoke).and_raise(StandardError, 'vault down')
+      described_class.revoke_bootstrap_lease
+      expect(described_class.instance_variable_get(:@bootstrap_lease_expires)).to be_nil
+    end
+
     it 'is idempotent — second call is a no-op' do
       described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
       described_class.revoke_bootstrap_lease

--- a/spec/legion/crypt/credential_scoping_spec.rb
+++ b/spec/legion/crypt/credential_scoping_spec.rb
@@ -1,0 +1,404 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Crypt do
+  let(:vault_response) do
+    double('Vault::Secret',
+           data:           { username: 'bootstrap_user', password: 'bootstrap_pass' },
+           lease_id:       'rabbitmq/creds/legionio-bootstrap/abc123',
+           lease_duration: 300,
+           renewable?:     false)
+  end
+
+  let(:identity_response) do
+    double('Vault::Secret',
+           data:           { username: 'identity_user', password: 'identity_pass' },
+           lease_id:       'rabbitmq/creds/legionio-infra/def456',
+           lease_duration: 604_800,
+           renewable?:     true)
+  end
+
+  let(:logical_double) { double('Vault::Logical') }
+  let(:sys_double)     { instance_double(Vault::Sys) }
+
+  before do
+    # Stub public Vault delegators on LeaseManager (vault_logical, vault_sys)
+    allow(Legion::Crypt::LeaseManager.instance).to receive(:vault_logical).and_return(logical_double)
+    allow(Legion::Crypt::LeaseManager.instance).to receive(:vault_sys).and_return(sys_double)
+    allow(logical_double).to receive(:read).and_return(vault_response)
+    allow(sys_double).to receive(:revoke)
+    # Reset instance-level state between examples
+    Legion::Crypt.instance_variable_set(:@bootstrap_lease_id, nil)
+    Legion::Crypt.instance_variable_set(:@bootstrap_lease_expires, nil)
+    Legion::Crypt::LeaseManager.instance.reset!
+  end
+
+  describe 'RMQ_ROLE_MAP' do
+    it 'maps :agent to legionio-infra' do
+      expect(described_class::RMQ_ROLE_MAP[:agent]).to eq('legionio-infra')
+    end
+
+    it 'maps :worker to legionio-worker' do
+      expect(described_class::RMQ_ROLE_MAP[:worker]).to eq('legionio-worker')
+    end
+
+    it 'maps :infra to legionio-infra' do
+      expect(described_class::RMQ_ROLE_MAP[:infra]).to eq('legionio-infra')
+    end
+
+    it 'is frozen' do
+      expect(described_class::RMQ_ROLE_MAP).to be_frozen
+    end
+  end
+
+  describe '.dynamic_rmq_creds?' do
+    it 'returns true when the setting is true' do
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = true
+      expect(described_class.dynamic_rmq_creds?).to be(true)
+    ensure
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+    end
+
+    it 'returns false when the setting is false' do
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+      expect(described_class.dynamic_rmq_creds?).to be(false)
+    end
+
+    it 'returns false when the setting is absent' do
+      Legion::Settings[:crypt][:vault].delete(:dynamic_rmq_creds)
+      expect(described_class.dynamic_rmq_creds?).to be(false)
+    ensure
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+    end
+  end
+
+  describe '.fetch_bootstrap_rmq_creds' do
+    before do
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = true
+      allow(described_class).to receive(:vault_connected?).and_return(true)
+      Legion::Settings.loader.settings[:transport] ||= {}
+      Legion::Settings.loader.settings[:transport][:connection] ||= {}
+    end
+
+    after do
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+    end
+
+    it 'reads from the bootstrap path' do
+      expect(logical_double).to receive(:read).with('rabbitmq/creds/legionio-bootstrap').and_return(vault_response)
+      described_class.fetch_bootstrap_rmq_creds
+    end
+
+    it 'stores the bootstrap lease_id' do
+      described_class.fetch_bootstrap_rmq_creds
+      expect(described_class.instance_variable_get(:@bootstrap_lease_id))
+        .to eq('rabbitmq/creds/legionio-bootstrap/abc123')
+    end
+
+    it 'stores a bootstrap_lease_expires time capped at 300 seconds' do
+      before_call = Time.now
+      described_class.fetch_bootstrap_rmq_creds
+      expires = described_class.instance_variable_get(:@bootstrap_lease_expires)
+      expect(expires).to be_a(Time)
+      expect(expires).to be >= before_call
+      expect(expires).to be <= (before_call + 300 + 1)
+    end
+
+    it 'writes username to the transport connection settings' do
+      described_class.fetch_bootstrap_rmq_creds
+      conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+      expect(conn[:user]).to eq('bootstrap_user')
+    end
+
+    it 'writes password to the transport connection settings' do
+      described_class.fetch_bootstrap_rmq_creds
+      conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+      expect(conn[:password]).to eq('bootstrap_pass')
+    end
+
+    context 'when vault is not connected' do
+      before { allow(described_class).to receive(:vault_connected?).and_return(false) }
+
+      it 'returns nil without reading from Vault' do
+        expect(logical_double).not_to receive(:read)
+        expect(described_class.fetch_bootstrap_rmq_creds).to be_nil
+      end
+    end
+
+    context 'when dynamic_rmq_creds? is false' do
+      before { Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false }
+
+      it 'returns nil without reading from Vault' do
+        expect(logical_double).not_to receive(:read)
+        expect(described_class.fetch_bootstrap_rmq_creds).to be_nil
+      end
+    end
+
+    context 'when Vault returns nil' do
+      before { allow(logical_double).to receive(:read).and_return(nil) }
+
+      it 'returns nil without raising' do
+        expect { described_class.fetch_bootstrap_rmq_creds }.not_to raise_error
+        expect(described_class.instance_variable_get(:@bootstrap_lease_id)).to be_nil
+      end
+    end
+
+    context 'when Vault returns a response with no data' do
+      let(:no_data_response) do
+        double('Vault::Secret', data: nil, lease_id: 'lease/abc', lease_duration: 300, renewable?: false)
+      end
+
+      before { allow(logical_double).to receive(:read).and_return(no_data_response) }
+
+      it 'returns nil without raising' do
+        expect { described_class.fetch_bootstrap_rmq_creds }.not_to raise_error
+      end
+    end
+
+    context 'when Vault raises an error' do
+      before { allow(logical_double).to receive(:read).and_raise(StandardError, 'vault unavailable') }
+
+      it 'does not raise and logs a warning' do
+        expect { described_class.fetch_bootstrap_rmq_creds }.not_to raise_error
+      end
+
+      it 'does not store a lease_id on error' do
+        described_class.fetch_bootstrap_rmq_creds
+        expect(described_class.instance_variable_get(:@bootstrap_lease_id)).to be_nil
+      end
+    end
+  end
+
+  describe '.swap_to_identity_creds' do
+    let(:transport_connection_double) do
+      double('Legion::Transport::Connection', session_open?: true)
+    end
+
+    before do
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = true
+      allow(described_class).to receive(:vault_connected?).and_return(true)
+      allow(logical_double).to receive(:read).with('rabbitmq/creds/legionio-infra').and_return(identity_response)
+      allow(logical_double).to receive(:read).with('rabbitmq/creds/legionio-worker').and_return(identity_response)
+      allow(logical_double).to receive(:read).with('rabbitmq/creds/legionio-custom').and_return(identity_response)
+      Legion::Settings.loader.settings[:transport] ||= {}
+      Legion::Settings.loader.settings[:transport][:connection] ||= {}
+    end
+
+    after do
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+    end
+
+    it 'returns early when vault is not connected' do
+      allow(described_class).to receive(:vault_connected?).and_return(false)
+      expect(logical_double).not_to receive(:read)
+      described_class.swap_to_identity_creds(mode: :agent)
+    end
+
+    it 'returns early when dynamic_rmq_creds? is false' do
+      Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+      expect(logical_double).not_to receive(:read)
+      described_class.swap_to_identity_creds(mode: :agent)
+    end
+
+    it 'returns early for :lite mode' do
+      expect(logical_double).not_to receive(:read)
+      described_class.swap_to_identity_creds(mode: :lite)
+    end
+
+    context 'role selection from RMQ_ROLE_MAP' do
+      before do
+        stub_const('Legion::Transport::Connection', transport_connection_double)
+        allow(transport_connection_double).to receive(:force_reconnect)
+        allow(Legion::Crypt::LeaseManager.instance).to receive(:register_dynamic_lease)
+      end
+
+      it 'uses legionio-infra for :agent mode' do
+        expect(logical_double).to receive(:read).with('rabbitmq/creds/legionio-infra').and_return(identity_response)
+        described_class.swap_to_identity_creds(mode: :agent)
+      end
+
+      it 'uses legionio-infra for :infra mode' do
+        expect(logical_double).to receive(:read).with('rabbitmq/creds/legionio-infra').and_return(identity_response)
+        described_class.swap_to_identity_creds(mode: :infra)
+      end
+
+      it 'uses legionio-worker for :worker mode' do
+        expect(logical_double).to receive(:read).with('rabbitmq/creds/legionio-worker').and_return(identity_response)
+        described_class.swap_to_identity_creds(mode: :worker)
+      end
+
+      it 'uses a fallback role name for unknown modes' do
+        expect(logical_double).to receive(:read).with('rabbitmq/creds/legionio-custom').and_return(identity_response)
+        described_class.swap_to_identity_creds(mode: :custom)
+      end
+    end
+
+    context 'when Vault returns identity creds' do
+      before do
+        stub_const('Legion::Transport::Connection', transport_connection_double)
+        allow(transport_connection_double).to receive(:force_reconnect)
+        allow(Legion::Crypt::LeaseManager.instance).to receive(:register_dynamic_lease)
+      end
+
+      it 'registers the lease with LeaseManager' do
+        expect(Legion::Crypt::LeaseManager.instance).to receive(:register_dynamic_lease).with(
+          name:          :rabbitmq,
+          path:          'rabbitmq/creds/legionio-infra',
+          response:      identity_response,
+          settings_refs: [
+            { path: %i[transport connection user],     key: :username },
+            { path: %i[transport connection password], key: :password }
+          ]
+        )
+        described_class.swap_to_identity_creds(mode: :agent)
+      end
+
+      it 'writes identity username to transport connection settings' do
+        described_class.swap_to_identity_creds(mode: :agent)
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+        expect(conn[:user]).to eq('identity_user')
+      end
+
+      it 'writes identity password to transport connection settings' do
+        described_class.swap_to_identity_creds(mode: :agent)
+        conn = Legion::Settings.loader.settings.dig(:transport, :connection)
+        expect(conn[:password]).to eq('identity_pass')
+      end
+
+      it 'calls force_reconnect on Transport::Connection' do
+        expect(transport_connection_double).to receive(:force_reconnect)
+        described_class.swap_to_identity_creds(mode: :agent)
+      end
+
+      it 'revokes the bootstrap lease after successful reconnect' do
+        described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/xyz789')
+        expect(sys_double).to receive(:revoke).with('boot/lease/xyz789')
+        described_class.swap_to_identity_creds(mode: :agent)
+      end
+    end
+
+    context 'when Vault returns no data for identity creds' do
+      before { allow(logical_double).to receive(:read).with('rabbitmq/creds/legionio-infra').and_return(nil) }
+
+      it 'raises an error' do
+        expect { described_class.swap_to_identity_creds(mode: :agent) }.to raise_error(RuntimeError, /Failed to fetch/)
+      end
+    end
+
+    context 'when Transport::Connection is not defined' do
+      before { allow(Legion::Crypt::LeaseManager.instance).to receive(:register_dynamic_lease) }
+
+      it 'does not raise when Transport module is absent' do
+        hide_const('Legion::Transport::Connection')
+        expect { described_class.swap_to_identity_creds(mode: :agent) }.not_to raise_error
+      end
+    end
+
+    context 'when transport reconnect fails (session not open)' do
+      let(:closed_connection) { double('Legion::Transport::Connection', session_open?: false) }
+
+      before do
+        stub_const('Legion::Transport::Connection', closed_connection)
+        allow(closed_connection).to receive(:force_reconnect)
+        allow(Legion::Crypt::LeaseManager.instance).to receive(:register_dynamic_lease)
+      end
+
+      it 'raises an error and does not revoke the bootstrap lease' do
+        described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/xyz789')
+        expect(sys_double).not_to receive(:revoke)
+        expect { described_class.swap_to_identity_creds(mode: :agent) }.to raise_error(RuntimeError, /reconnect failed/)
+      end
+    end
+  end
+
+  describe '.revoke_bootstrap_lease' do
+    it 'is a no-op when no bootstrap lease is stored' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, nil)
+      expect(sys_double).not_to receive(:revoke)
+      expect { described_class.revoke_bootstrap_lease }.not_to raise_error
+    end
+
+    it 'revokes the stored bootstrap lease' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
+      expect(sys_double).to receive(:revoke).with('boot/lease/abc123')
+      described_class.revoke_bootstrap_lease
+    end
+
+    it 'clears @bootstrap_lease_id after revocation' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
+      described_class.revoke_bootstrap_lease
+      expect(described_class.instance_variable_get(:@bootstrap_lease_id)).to be_nil
+    end
+
+    it 'clears @bootstrap_lease_expires after revocation' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
+      described_class.instance_variable_set(:@bootstrap_lease_expires, Time.now + 100)
+      described_class.revoke_bootstrap_lease
+      expect(described_class.instance_variable_get(:@bootstrap_lease_expires)).to be_nil
+    end
+
+    it 'does not raise when Vault revocation fails' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
+      allow(sys_double).to receive(:revoke).and_raise(StandardError, 'vault down')
+      expect { described_class.revoke_bootstrap_lease }.not_to raise_error
+    end
+
+    it 'clears @bootstrap_lease_id even when revocation fails' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
+      allow(sys_double).to receive(:revoke).and_raise(StandardError, 'vault down')
+      described_class.revoke_bootstrap_lease
+      expect(described_class.instance_variable_get(:@bootstrap_lease_id)).to be_nil
+    end
+
+    it 'is idempotent — second call is a no-op' do
+      described_class.instance_variable_set(:@bootstrap_lease_id, 'boot/lease/abc123')
+      described_class.revoke_bootstrap_lease
+      expect(sys_double).not_to receive(:revoke)
+      described_class.revoke_bootstrap_lease
+    end
+  end
+
+  describe 'start_lease_manager with dynamic_rmq_creds guard' do
+    before do
+      allow(Legion::Crypt::LeaseManager.instance).to receive(:start)
+      allow(Legion::Crypt::LeaseManager.instance).to receive(:start_renewal_thread)
+      allow(Legion::Crypt::LeaseManager.instance).to receive(:shutdown)
+    end
+
+    context 'when dynamic_rmq_creds is true and no static leases' do
+      before do
+        Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = true
+        Legion::Settings[:crypt][:vault][:connected] = true
+        Legion::Settings[:crypt][:vault][:leases] = {}
+      end
+
+      after do
+        Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+        Legion::Settings[:crypt][:vault][:connected] = false
+      end
+
+      it 'starts the renewal thread even without static leases' do
+        Legion::Crypt.send(:start_lease_manager)
+        expect(Legion::Crypt::LeaseManager.instance).to have_received(:start_renewal_thread)
+      end
+    end
+
+    context 'when dynamic_rmq_creds is false and no static leases' do
+      before do
+        Legion::Settings[:crypt][:vault][:dynamic_rmq_creds] = false
+        Legion::Settings[:crypt][:vault][:connected] = true
+        Legion::Settings[:crypt][:vault][:leases] = {}
+      end
+
+      after do
+        Legion::Settings[:crypt][:vault][:connected] = false
+      end
+
+      it 'does not start the renewal thread without static leases' do
+        Legion::Crypt.send(:start_lease_manager)
+        expect(Legion::Crypt::LeaseManager.instance).not_to have_received(:start_renewal_thread)
+      end
+    end
+  end
+end

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -583,6 +583,25 @@ RSpec.describe Legion::Crypt::LeaseManager do
       expect(manager.active_leases[:rabbitmq][:expires_at]).to be >= before_call
     end
 
+    it 'updates lease_duration in active_leases from the reissued response' do
+      manager.reissue_lease(:rabbitmq)
+      expect(manager.active_leases[:rabbitmq][:lease_duration]).to eq(604_800)
+    end
+
+    it 'updates renewable in active_leases from the reissued response' do
+      manager.reissue_lease(:rabbitmq)
+      expect(manager.active_leases[:rabbitmq][:renewable]).to be(true)
+    end
+
+    it 'does not raise when the active_leases entry is removed before the synchronize block runs' do
+      # Simulate the entry being removed (e.g. during shutdown) between the initial read and the merge
+      allow(Vault).to receive_message_chain(:logical, :read).and_return(reissued_response) do
+        manager.instance_variable_get(:@active_leases).delete(:rabbitmq)
+        reissued_response
+      end
+      expect { manager.reissue_lease(:rabbitmq) }.not_to raise_error
+    end
+
     it 'updates fetched_at in active_leases' do
       before_call = Time.now
       manager.reissue_lease(:rabbitmq)

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -428,4 +428,230 @@ RSpec.describe Legion::Crypt::LeaseManager do
       manager.shutdown
     end
   end
+
+  describe '#register_dynamic_lease' do
+    let(:dynamic_response) do
+      double('Vault::Secret',
+             data:           { username: 'dyn_user', password: 'dyn_pass' },
+             lease_id:       'rabbitmq/creds/legionio-infra/dyn123',
+             lease_duration: 604_800,
+             renewable?:     true)
+    end
+
+    it 'populates the lease cache with credential data' do
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: []
+      )
+      expect(manager.lease_data(:rabbitmq)).to eq({ username: 'dyn_user', password: 'dyn_pass' })
+    end
+
+    it 'stores the lease_id in active_leases' do
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: []
+      )
+      expect(manager.active_leases[:rabbitmq][:lease_id]).to eq('rabbitmq/creds/legionio-infra/dyn123')
+    end
+
+    it 'stores lease_duration in active_leases' do
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: []
+      )
+      expect(manager.active_leases[:rabbitmq][:lease_duration]).to eq(604_800)
+    end
+
+    it 'stores fetched_at in active_leases as a Time' do
+      before_call = Time.now
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: []
+      )
+      expect(manager.active_leases[:rabbitmq][:fetched_at]).to be_a(Time)
+      expect(manager.active_leases[:rabbitmq][:fetched_at]).to be >= before_call
+    end
+
+    it 'stores renewable via predicate method (true)' do
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: []
+      )
+      expect(manager.active_leases[:rabbitmq][:renewable]).to be(true)
+    end
+
+    it 'stores the path for reissue' do
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: []
+      )
+      expect(manager.active_leases[:rabbitmq][:path]).to eq('rabbitmq/creds/legionio-infra')
+    end
+
+    it 'registers settings refs provided' do
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: [
+          { path: %i[transport connection user],     key: :username },
+          { path: %i[transport connection password], key: :password }
+        ]
+      )
+      refs = manager.instance_variable_get(:@refs)
+      expect(refs[:rabbitmq][:username]).to eq(%i[transport connection user])
+      expect(refs[:rabbitmq][:password]).to eq(%i[transport connection password])
+    end
+
+    it 'is wrapped in state_mutex synchronize (idempotent on re-registration)' do
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      dynamic_response,
+        settings_refs: []
+      )
+      expect do
+        manager.register_dynamic_lease(
+          name:          :rabbitmq,
+          path:          'rabbitmq/creds/legionio-infra',
+          response:      dynamic_response,
+          settings_refs: []
+        )
+      end.not_to raise_error
+    end
+  end
+
+  describe '#reissue_lease' do
+    let(:original_response) do
+      double('Vault::Secret',
+             data:           { username: 'orig_user', password: 'orig_pass' },
+             lease_id:       'rabbitmq/creds/legionio-infra/orig111',
+             lease_duration: 604_800,
+             renewable?:     true)
+    end
+
+    let(:reissued_response) do
+      double('Vault::Secret',
+             data:           { username: 'new_user', password: 'new_pass' },
+             lease_id:       'rabbitmq/creds/legionio-infra/new222',
+             lease_duration: 604_800,
+             renewable?:     true)
+    end
+
+    before do
+      allow(Vault).to receive_message_chain(:logical, :read).and_return(reissued_response)
+      manager.register_dynamic_lease(
+        name:          :rabbitmq,
+        path:          'rabbitmq/creds/legionio-infra',
+        response:      original_response,
+        settings_refs: []
+      )
+    end
+
+    it 'reads from the stored path' do
+      logical_double = double('Vault::Logical')
+      allow(Vault).to receive(:logical).and_return(logical_double)
+      expect(logical_double).to receive(:read).with('rabbitmq/creds/legionio-infra').and_return(reissued_response)
+      manager.reissue_lease(:rabbitmq)
+    end
+
+    it 'updates the lease cache with new credentials' do
+      manager.reissue_lease(:rabbitmq)
+      expect(manager.fetch(:rabbitmq, :username)).to eq('new_user')
+    end
+
+    it 'updates the lease_id in active_leases' do
+      manager.reissue_lease(:rabbitmq)
+      expect(manager.active_leases[:rabbitmq][:lease_id]).to eq('rabbitmq/creds/legionio-infra/new222')
+    end
+
+    it 'updates the expires_at in active_leases' do
+      before_call = Time.now
+      manager.reissue_lease(:rabbitmq)
+      expect(manager.active_leases[:rabbitmq][:expires_at]).to be >= before_call
+    end
+
+    it 'updates fetched_at in active_leases' do
+      before_call = Time.now
+      manager.reissue_lease(:rabbitmq)
+      expect(manager.active_leases[:rabbitmq][:fetched_at]).to be >= before_call
+    end
+
+    it 'returns early for an unknown lease name' do
+      expect { manager.reissue_lease(:unknown_lease) }.not_to raise_error
+    end
+
+    it 'returns early for a lease without a path' do
+      manager.active_leases[:rabbitmq].delete(:path)
+      expect(Vault.logical).not_to receive(:read)
+      manager.reissue_lease(:rabbitmq)
+    end
+
+    it 'returns early when Vault returns nil' do
+      allow(Vault).to receive_message_chain(:logical, :read).and_return(nil)
+      expect { manager.reissue_lease(:rabbitmq) }.not_to raise_error
+    end
+
+    it 'handles StandardError gracefully without raising' do
+      allow(Vault).to receive_message_chain(:logical, :read).and_raise(StandardError, 'network error')
+      expect { manager.reissue_lease(:rabbitmq) }.not_to raise_error
+    end
+
+    context 'when name is :rabbitmq and Transport::Connection is defined' do
+      let(:transport_conn_double) { double('Legion::Transport::Connection') }
+
+      before do
+        stub_const('Legion::Transport::Connection', transport_conn_double)
+        allow(transport_conn_double).to receive(:force_reconnect)
+      end
+
+      it 'calls force_reconnect on Transport::Connection' do
+        expect(transport_conn_double).to receive(:force_reconnect)
+        manager.reissue_lease(:rabbitmq)
+      end
+    end
+
+    context 'when name is not :rabbitmq' do
+      let(:kv_response) do
+        double('Vault::Secret',
+               data:           { token: 'new_token' },
+               lease_id:       'kv/some/path/token333',
+               lease_duration: 3600,
+               renewable?:     true)
+      end
+
+      before do
+        allow(Vault).to receive_message_chain(:logical, :read).and_return(kv_response)
+        manager.register_dynamic_lease(
+          name:          :kv_token,
+          path:          'kv/some/path',
+          response:      double('Vault::Secret',
+                                data:           { token: 'old_token' },
+                                lease_id:       'kv/some/path/old111',
+                                lease_duration: 3600,
+                                renewable?:     true),
+          settings_refs: []
+        )
+      end
+
+      it 'does not call force_reconnect for non-rabbitmq leases' do
+        transport_conn = double('Legion::Transport::Connection')
+        stub_const('Legion::Transport::Connection', transport_conn)
+        expect(transport_conn).not_to receive(:force_reconnect)
+        manager.reissue_lease(:kv_token)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Implements all Group 3 tasks from the [Phase 5 Credential Scoping design doc](../docs/plans/2026-04-07-credential-scoping-design.md) §4 in `legion-crypt`
- Adds bootstrap RabbitMQ credential fetch (`fetch_bootstrap_rmq_creds`) gated on `vault_connected? && dynamic_rmq_creds?`
- Adds identity-scoped credential swap (`swap_to_identity_creds(mode:)`) using `RMQ_ROLE_MAP` for role selection per process mode
- Adds `revoke_bootstrap_lease` — non-fatal, idempotent; called after successful reconnect
- Extends `LeaseManager` with `register_dynamic_lease`, `reissue_lease`, and public `vault_logical`/`vault_sys` delegators
- Guards `start_lease_manager` to start the renewal thread when `dynamic_rmq_creds: true` even with no static leases
- Adds `dynamic_rmq_creds: false` and `dynamic_pg_creds: false` to vault settings defaults

## Key Design Points

- `RMQ_ROLE_MAP`: `:agent` → `'legionio-infra'`, `:worker` → `'legionio-worker'`, `:infra` → `'legionio-infra'`
- Bootstrap creds bypass `LeaseManager` — transient, not renewed, explicitly revoked after identity swap
- All new behavior is gated behind `dynamic_rmq_creds: false` (default) — no behavior change for existing deployments
- `force_reconnect` called without `reason:` kwarg (matches current Transport signature)
- Bootstrap lease NOT revoked if `session_open?` returns false after reconnect — preserves connectivity
- `reissue_lease` performs full `logical.read` (not `sys.renew`) for RabbitMQ rotation since Vault RMQ renewal only extends TTL, does not rotate credentials
- `register_dynamic_lease` stores `fetched_at`, `lease_duration`, `renewable` (via predicate), and `path` — required for renewal loop to pick up dynamically-registered leases

## Test Plan

- [ ] All 67 new examples in `spec/legion/crypt/credential_scoping_spec.rb` and new examples in `spec/legion/lease_manager_spec.rb` pass
- [ ] Full suite green (exit 0)
- [ ] Rubocop clean (exit 0)
- [ ] Verify `dynamic_rmq_creds: false` default preserves existing behavior
- [ ] Verify `fetch_bootstrap_rmq_creds` is a no-op when Vault is not connected
- [ ] Verify `revoke_bootstrap_lease` is idempotent and non-fatal on Vault failure
- [ ] Integration: boot with `dynamic_rmq_creds: true` after Group 1 (Terraform) is deployed