### PR TITLE
add VaultEntity module for Phase 7 Vault identity tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [1.5.7] - 2026-04-08
+
+### Fixed
+- `LeaseManager#cache_lease` now stores the `:path` from static lease definitions, enabling `reissue_lease` fallback when `sys.renew` fails or leases hit max_ttl — previously static leases (configured via `crypt.vault.leases`) would silently expire after their TTL with no recovery (fixes #28)
+- `LeaseManager#renew_lease` now logs a warning and falls back to reissue when the path is available, or warns explicitly when no path is available — previously renewal failures for pathless leases were silent
+
+### Added
+- `LeaseManager#trigger_reconnect(name)` — dispatches reconnect to the appropriate service after credential reissue: `:rabbitmq` → `Transport::Connection.force_reconnect`, `:postgresql` → `Data.reconnect`, `:redis` → `Cache.reconnect`; all guarded with `defined?`/`respond_to?` and rescue-safe
+- Comprehensive INFO/WARN logging across the entire lease lifecycle:
+  - INFO on lease fetch attempt, fetch success (with lease_id/ttl/renewable), renewal attempt, renewal success (with new_ttl), reissue attempt, reissue success (with new_lease_id/ttl), approaching expiry detection (with remaining/renewable/has_path), credentials changed during renewal, reconnect triggered, renewal loop start/exit
+  - WARN on non-renewable lease with no reissue path, renewal failure with no reissue path, reissue returning no data, reconnect failure, cannot reissue due to missing path
+
+### Changed
+- `LeaseManager#reissue_lease` now calls `trigger_reconnect(name)` instead of inline `:rabbitmq`-only `force_reconnect`, extending credential rotation reconnect support to PostgreSQL and Redis
+
 ## [1.5.6] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 - `VaultEntity` module (`lib/legion/crypt/vault_entity.rb`) — Phase 7 Vault identity tracking
   - `ensure_entity(principal_id:, canonical_name:, metadata: {})` — creates or finds a Vault entity for a Legion principal; entity names are prefixed with `legion-` to avoid collision; metadata includes `legion_principal_id`, `legion_canonical_name`, and `managed_by: 'legion'`; returns entity ID string or nil on failure (non-fatal)
-  - `ensure_alias(entity_id:, mount_accessor:, alias_name:)` — creates an entity alias linking an auth method mount to the entity; idempotent (`already exists` HTTPClientError is swallowed); other 4xx errors re-raise
+  - `ensure_alias(entity_id:, mount_accessor:, alias_name:)` — creates an entity alias linking an auth method mount to the entity; idempotent (`already exists` HTTPClientError is swallowed); all other `Vault::HTTPClientError` responses log warn and return nil (non-fatal)
   - `find_by_name(canonical_name)` — looks up a Vault entity by its Legion canonical name via `identity/entity/name/legion-{name}`; returns entity ID or nil
   - All operations are non-fatal — rescue and log warn on failure; boot/request flow is never blocked by entity tracking errors
   - Delegates Vault API calls to `LeaseManager.instance.vault_logical` (public delegator) when available; falls back to `::Vault.logical`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.5.6] - 2026-04-07
+
+### Added
+- `VaultEntity` module (`lib/legion/crypt/vault_entity.rb`) — Phase 7 Vault identity tracking
+  - `ensure_entity(principal_id:, canonical_name:, metadata: {})` — creates or finds a Vault entity for a Legion principal; entity names are prefixed with `legion-` to avoid collision; metadata includes `legion_principal_id`, `legion_canonical_name`, and `managed_by: 'legion'`; returns entity ID string or nil on failure (non-fatal)
+  - `ensure_alias(entity_id:, mount_accessor:, alias_name:)` — creates an entity alias linking an auth method mount to the entity; idempotent (`already exists` HTTPClientError is swallowed); other 4xx errors re-raise
+  - `find_by_name(canonical_name)` — looks up a Vault entity by its Legion canonical name via `identity/entity/name/legion-{name}`; returns entity ID or nil
+  - All operations are non-fatal — rescue and log warn on failure; boot/request flow is never blocked by entity tracking errors
+  - Delegates Vault API calls to `LeaseManager.instance.vault_logical` (public delegator) when available; falls back to `::Vault.logical`
+
 ## [1.5.5] - 2026-04-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Legion::Crypt (singleton module)
 ├── Spiffe::IdentityHelpers  # Mixin for SPIFFE identity operations
 ├── Spiffe::SvidRotation     # Background SVID renewal at 50% TTL
 ├── Spiffe::WorkloadApiClient # gRPC workload API client for SPIRE agent (unix socket)
+├── VaultEntity        # Vault entity/alias lifecycle (ensure_entity, ensure_alias, find_by_name); all non-fatal
 ├── MockVault          # In-memory Vault mock for local development mode
 ├── Settings           # Default crypt config
 └── Version
@@ -140,6 +141,7 @@ Dev dependencies: `legion-logging`, `legion-settings`
 | `lib/legion/crypt/spiffe/identity_helpers.rb` | Mixin for SPIFFE identity operations |
 | `lib/legion/crypt/spiffe/svid_rotation.rb` | Background SVID renewal thread (50% TTL) |
 | `lib/legion/crypt/spiffe/workload_api_client.rb` | gRPC workload API client for SPIRE agent |
+| `lib/legion/crypt/vault_entity.rb` | Vault entity/alias lifecycle: `ensure_entity`, `ensure_alias`, `find_by_name`; all operations non-fatal |
 | `lib/legion/crypt/version.rb` | VERSION constant |
 
 ## Role in LegionIO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 Handles encryption, decryption, secrets management, JWT token management, and HashiCorp Vault connectivity for the LegionIO framework. Provides AES-256-CBC message encryption, RSA key pair generation, cluster secret management, JWT issue/verify operations, and Vault token lifecycle management.
 
 **GitHub**: https://github.com/LegionIO/legion-crypt
-**Version**: 1.5.3
+**Version**: 1.5.6
 **License**: Apache-2.0
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 Handles encryption, decryption, secrets management, JWT token management, and HashiCorp Vault connectivity for the LegionIO framework. Provides AES-256-CBC message encryption, RSA key pair generation, cluster secret management, JWT issue/verify operations, and Vault token lifecycle management.
 
 **GitHub**: https://github.com/LegionIO/legion-crypt
-**Version**: 1.4.15
+**Version**: 1.5.3
 **License**: Apache-2.0
 
 ## Architecture
@@ -63,6 +63,10 @@ Legion::Crypt (singleton module)
 ├── Tls                # TLS settings (cert/key/CA/verify_peer/Vault PKI)
 ├── Mtls               # mTLS cert issuance (Vault PKI) + CertRotation background thread (50% TTL renewal)
 ├── TokenRenewer       # Background renewal thread: 75% TTL renew, Kerberos re-auth on failure, exponential backoff
+├── Spiffe             # SPIFFE identity support: parse_id, valid_id?, X509Svid, JwtSvid structs; reads security.spiffe settings
+├── Spiffe::IdentityHelpers  # Mixin for SPIFFE identity operations
+├── Spiffe::SvidRotation     # Background SVID renewal at 50% TTL
+├── Spiffe::WorkloadApiClient # gRPC workload API client for SPIRE agent (unix socket)
 ├── MockVault          # In-memory Vault mock for local development mode
 ├── Settings           # Default crypt config
 └── Version
@@ -132,6 +136,10 @@ Dev dependencies: `legion-logging`, `legion-settings`
 | `lib/legion/crypt/tls.rb` | TLS settings module (cert, key, CA paths, verify_peer, Vault PKI flag) |
 | `lib/legion/crypt/mtls.rb` | mTLS certificate issuance from Vault PKI; `CertRotation` background renewal thread (50% TTL) |
 | `lib/legion/crypt/token_renewer.rb` | Plain Thread renewer: renews at 75% TTL, re-auths via Kerberos on failure, exponential backoff |
+| `lib/legion/crypt/spiffe.rb` | SPIFFE identity: parse/validate SPIFFE IDs, X509Svid/JwtSvid structs, settings helpers |
+| `lib/legion/crypt/spiffe/identity_helpers.rb` | Mixin for SPIFFE identity operations |
+| `lib/legion/crypt/spiffe/svid_rotation.rb` | Background SVID renewal thread (50% TTL) |
+| `lib/legion/crypt/spiffe/workload_api_client.rb` | gRPC workload API client for SPIRE agent |
 | `lib/legion/crypt/version.rb` | VERSION constant |
 
 ## Role in LegionIO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 Handles encryption, decryption, secrets management, JWT token management, and HashiCorp Vault connectivity for the LegionIO framework. Provides AES-256-CBC message encryption, RSA key pair generation, cluster secret management, JWT issue/verify operations, and Vault token lifecycle management.
 
 **GitHub**: https://github.com/LegionIO/legion-crypt
-**Version**: 1.5.6
+**Version**: 1.5.7
 **License**: Apache-2.0
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Encryption, secrets management, JWT token management, and HashiCorp Vault integration for the [LegionIO](https://github.com/LegionIO/LegionIO) framework. Provides AES-256-CBC message encryption, RSA key pair generation, cluster secret management, JWT issue/verify operations, Vault token lifecycle management, and multi-cluster Vault connectivity.
 
-**Version**: 1.4.22
+**Version**: 1.5.3
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Encryption, secrets management, JWT token management, and HashiCorp Vault integration for the [LegionIO](https://github.com/LegionIO/LegionIO) framework. Provides AES-256-CBC message encryption, RSA key pair generation, cluster secret management, JWT issue/verify operations, Vault token lifecycle management, and multi-cluster Vault connectivity.
 
-**Version**: 1.5.3
+**Version**: 1.5.6
 
 ## Installation
 

--- a/lib/legion/crypt.rb
+++ b/lib/legion/crypt.rb
@@ -138,6 +138,7 @@ module Legion
 
         log.info "Bootstrap RMQ credentials acquired (lease: #{@bootstrap_lease_id[0..7]}...)"
       rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'crypt.fetch_bootstrap_rmq_creds')
         log.warn "Bootstrap RMQ credential fetch failed: #{e.message}"
       end
 
@@ -188,6 +189,7 @@ module Legion
         @bootstrap_lease_id      = nil
         @bootstrap_lease_expires = nil
       rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'crypt.revoke_bootstrap_lease')
         log.warn "Bootstrap lease revocation failed: #{e.message} — lease will expire naturally"
         @bootstrap_lease_id      = nil
         @bootstrap_lease_expires = nil

--- a/lib/legion/crypt/jwks_client.rb
+++ b/lib/legion/crypt/jwks_client.rb
@@ -61,6 +61,7 @@ module Legion
           Thread.new do
             fetch_keys(jwks_url)
           rescue StandardError => e
+            handle_exception(e, level: :debug, operation: 'crypt.jwks.prefetch', jwks_url: jwks_url) if respond_to?(:handle_exception)
             log.debug "JWKS prefetch failed for #{jwks_url}: #{e.message}" if respond_to?(:log)
           end
         end
@@ -71,6 +72,7 @@ module Legion
           @refresh_task = Concurrent::TimerTask.new(execution_interval: interval, run_now: false) do
             fetch_keys(jwks_url)
           rescue StandardError => e
+            handle_exception(e, level: :debug, operation: 'crypt.jwks.background_refresh', jwks_url: jwks_url) if respond_to?(:handle_exception)
             log.debug "JWKS background refresh failed: #{e.message}" if respond_to?(:log)
           end
           @refresh_task.execute
@@ -121,7 +123,10 @@ module Legion
 
           response.body
         rescue StandardError => e
-          raise Legion::Crypt::JWT::Error, "failed to fetch JWKS: #{e.message}" unless e.is_a?(Legion::Crypt::JWT::Error)
+          unless e.is_a?(Legion::Crypt::JWT::Error)
+            handle_exception(e, level: :warn, operation: 'crypt.jwks.http_get', url: url) if respond_to?(:handle_exception)
+            raise Legion::Crypt::JWT::Error, "failed to fetch JWKS: #{e.message}"
+          end
 
           raise
         end

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -40,6 +40,7 @@ module Legion
           revoke_expired_lease(name)
 
           begin
+            log.info("LeaseManager: fetching lease '#{name}' from #{path}")
             response = logical.read(path)
             unless response
               log.warn("LeaseManager: no data at '#{name}' (#{path}) — path may not exist or role not configured")
@@ -47,8 +48,9 @@ module Legion
             end
 
             log_lease_response(name, response)
-            cache_lease(name, response)
-            log.info("LeaseManager: fetched lease for '#{name}' from #{path}")
+            cache_lease(name, response, path: path)
+            log.info("LeaseManager: fetched lease '#{name}' from #{path} " \
+                     "(lease_id=#{response.lease_id[0..11]}... ttl=#{response.lease_duration}s renewable=#{response.renewable?})")
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'crypt.lease_manager.start', lease_name: name, path: path)
             log.warn("LeaseManager: failed to fetch lease '#{name}' from #{path}: #{e.message}")
@@ -129,10 +131,17 @@ module Legion
 
       def reissue_lease(name)
         lease = @state_mutex.synchronize { @active_leases[name]&.dup }
-        return unless lease && lease[:path]
+        unless lease && lease[:path]
+          log.warn("LeaseManager: cannot reissue lease '#{name}' — no path stored for re-read")
+          return
+        end
 
+        log.info("LeaseManager: reissuing lease '#{name}' from #{lease[:path]}")
         response = logical.read(lease[:path])
-        return unless response&.data
+        unless response&.data
+          log.warn("LeaseManager: reissue for '#{name}' returned no data from #{lease[:path]}")
+          return
+        end
 
         @state_mutex.synchronize do
           active_lease = @active_leases[name]
@@ -147,12 +156,10 @@ module Legion
             renewable:      response.renewable?
           )
         end
+        log.info("LeaseManager: reissued lease '#{name}' " \
+                 "(new_lease_id=#{response.lease_id[0..11]}... ttl=#{response.lease_duration}s)")
         push_to_settings(name)
-
-        return unless name == :rabbitmq && defined?(Legion::Transport::Connection)
-
-        Legion::Transport::Connection.force_reconnect
-        log.info("LeaseManager: reissued lease '#{name}' and triggered transport reconnect")
+        trigger_reconnect(name)
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'crypt.lease_manager.reissue_lease', lease_name: name)
         log.warn("LeaseManager: failed to reissue lease '#{name}': #{e.message}")
@@ -227,7 +234,7 @@ module Legion
         @at_exit_registered = true
       end
 
-      def cache_lease(name, response)
+      def cache_lease(name, response, path: nil)
         @state_mutex.synchronize do
           @lease_cache[name] = response.data || {}
           @active_leases[name] = {
@@ -235,7 +242,8 @@ module Legion
             lease_duration: response.lease_duration,
             renewable:      response.renewable?,
             expires_at:     Time.now + (response.lease_duration || 0),
-            fetched_at:     Time.now
+            fetched_at:     Time.now,
+            path:           path
           }
         end
       end
@@ -286,13 +294,15 @@ module Legion
       end
 
       def renewal_loop
+        log.info 'LeaseManager: renewal loop started'
         while running?
           interruptible_sleep(RENEWAL_CHECK_INTERVAL)
           renew_approaching_leases if running?
         end
+        log.info 'LeaseManager: renewal loop exiting'
       rescue StandardError => e
         handle_exception(e, level: :error, operation: 'crypt.lease_manager.renewal_loop')
-        log.error("LeaseManager: renewal loop error: #{e.message}")
+        log.error("LeaseManager: renewal loop error: #{e.message} — restarting")
         retry if running?
       end
 
@@ -303,36 +313,52 @@ module Legion
           next unless lease
           next unless approaching_expiry?(lease)
 
+          remaining = lease[:expires_at] ? (lease[:expires_at] - Time.now).round(1) : 'unknown'
+          log.info("LeaseManager: lease '#{name}' approaching expiry " \
+                   "(remaining=#{remaining}s renewable=#{lease[:renewable]} has_path=#{!lease[:path].nil?})")
+
           if lease[:renewable]
             renew_lease(name, lease)
           elsif lease[:path]
-            log.info("LeaseManager: lease '#{name}' is non-renewable and approaching expiry — re-issuing")
+            log.info("LeaseManager: lease '#{name}' is non-renewable — re-issuing from #{lease[:path]}")
             reissue_lease(name)
+          else
+            log.warn("LeaseManager: lease '#{name}' is non-renewable and has no path for reissue — " \
+                     "will expire at #{lease[:expires_at]}")
           end
         end
       end
 
       def renew_lease(name, lease)
+        log.info("LeaseManager: renewing lease '#{name}' (lease_id=#{lease[:lease_id][0..11]}...)")
         response = sys.renew(lease[:lease_id])
+        new_ttl = response.respond_to?(:lease_duration) ? response.lease_duration : nil
         @state_mutex.synchronize do
           current_lease = @active_leases[name]
           next unless current_lease
 
-          current_lease[:lease_duration] = response.lease_duration if response.respond_to?(:lease_duration)
+          current_lease[:lease_duration] = new_ttl if new_ttl
           current_lease[:renewable] = response.renewable? if response.respond_to?(:renewable?)
-          current_lease[:expires_at] = Time.now + (response.lease_duration || 0)
+          current_lease[:expires_at] = Time.now + (new_ttl || 0)
         end
-        log.info("LeaseManager: renewed lease '#{name}'")
+        log.info("LeaseManager: renewed lease '#{name}' (new_ttl=#{new_ttl}s)")
 
         cached_data = @state_mutex.synchronize { @lease_cache[name] }
         if response.data && response.data != cached_data
           @state_mutex.synchronize { @lease_cache[name] = response.data }
           push_to_settings(name)
+          log.info("LeaseManager: lease '#{name}' credentials changed during renewal — settings updated")
         end
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'crypt.lease_manager.renew_lease', lease_name: name)
         log.warn("LeaseManager: failed to renew lease '#{name}': #{e.message}")
-        reissue_lease(name) if lease[:path]
+        if lease[:path]
+          log.warn("LeaseManager: falling back to reissue for '#{name}' from #{lease[:path]}")
+          reissue_lease(name)
+        else
+          log.warn("LeaseManager: lease '#{name}' renewal failed and no path available for reissue — " \
+                   "lease will expire at #{lease[:expires_at]}")
+        end
       end
 
       def lease_valid?(name)
@@ -388,6 +414,29 @@ module Legion
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'crypt.lease_manager.write_setting', path: path.join('.'))
         log.warn("LeaseManager: failed to write setting at #{path.join('.')}: #{e.message}")
+      end
+
+      def trigger_reconnect(name)
+        case name
+        when :rabbitmq
+          return unless defined?(Legion::Transport::Connection)
+
+          Legion::Transport::Connection.force_reconnect
+          log.info("LeaseManager: triggered transport reconnect after '#{name}' reissue")
+        when :postgresql
+          return unless defined?(Legion::Data) && Legion::Data.respond_to?(:reconnect)
+
+          Legion::Data.reconnect
+          log.info("LeaseManager: triggered data reconnect after '#{name}' reissue")
+        when :redis
+          return unless defined?(Legion::Cache) && Legion::Cache.respond_to?(:reconnect)
+
+          Legion::Cache.reconnect
+          log.info("LeaseManager: triggered cache reconnect after '#{name}' reissue")
+        end
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
+        log.warn("LeaseManager: reconnect for '#{name}' failed: #{e.message}")
       end
 
       def running?

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -50,7 +50,7 @@ module Legion
             log_lease_response(name, response)
             cache_lease(name, response, path: path)
             log.info("LeaseManager: fetched lease '#{name}' from #{path} " \
-                     "(lease_id=#{response.lease_id[0..11]}... ttl=#{response.lease_duration}s renewable=#{response.renewable?})")
+                     "(lease_id=#{response.lease_id.to_s[0..11]}... ttl=#{response.lease_duration}s renewable=#{response.renewable?})")
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'crypt.lease_manager.start', lease_name: name, path: path)
             log.warn("LeaseManager: failed to fetch lease '#{name}' from #{path}: #{e.message}")
@@ -156,8 +156,9 @@ module Legion
             renewable:      response.renewable?
           )
         end
+        lease_id_preview = response.lease_id.to_s[0..11]
         log.info("LeaseManager: reissued lease '#{name}' " \
-                 "(new_lease_id=#{response.lease_id[0..11]}... ttl=#{response.lease_duration}s)")
+                 "(new_lease_id=#{lease_id_preview}... ttl=#{response.lease_duration}s)")
         push_to_settings(name)
         trigger_reconnect(name)
       rescue StandardError => e
@@ -330,8 +331,21 @@ module Legion
       end
 
       def renew_lease(name, lease)
-        log.info("LeaseManager: renewing lease '#{name}' (lease_id=#{lease[:lease_id][0..11]}...)")
-        response = sys.renew(lease[:lease_id])
+        lease_id = lease[:lease_id].to_s
+        if lease_id.empty?
+          log.warn("LeaseManager: lease '#{name}' is renewable but has no lease_id")
+          if lease[:path]
+            log.warn("LeaseManager: falling back to reissue for '#{name}' from #{lease[:path]}")
+            reissue_lease(name)
+          else
+            log.warn("LeaseManager: lease '#{name}' renewal failed and no path available for reissue — " \
+                     "lease will expire at #{lease[:expires_at]}")
+          end
+          return
+        end
+
+        log.info("LeaseManager: renewing lease '#{name}' (lease_id=#{lease_id[0..11]}...)")
+        response = sys.renew(lease_id)
         new_ttl = response.respond_to?(:lease_duration) ? response.lease_duration : nil
         @state_mutex.synchronize do
           current_lease = @active_leases[name]
@@ -417,6 +431,7 @@ module Legion
       end
 
       def trigger_reconnect(name)
+        name = name.to_sym if name.respond_to?(:to_sym)
         case name
         when :rabbitmq
           return unless defined?(Legion::Transport::Connection)

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -143,9 +143,9 @@ module Legion
           return
         end
 
-        @state_mutex.synchronize do
+        updated = @state_mutex.synchronize do
           active_lease = @active_leases[name]
-          next unless active_lease
+          next false unless active_lease
 
           @lease_cache[name] = response.data
           active_lease.merge!(
@@ -155,7 +155,13 @@ module Legion
             fetched_at:     Time.now,
             renewable:      response.renewable?
           )
+          true
         end
+        unless updated
+          log.warn("LeaseManager: reissue for '#{name}' skipped — lease was removed during reissue (likely shutdown)")
+          return
+        end
+
         lease_id_preview = response.lease_id.to_s[0..11]
         log.info("LeaseManager: reissued lease '#{name}' " \
                  "(new_lease_id=#{lease_id_preview}... ttl=#{response.lease_duration}s)")
@@ -315,8 +321,8 @@ module Legion
           next unless approaching_expiry?(lease)
 
           remaining = lease[:expires_at] ? (lease[:expires_at] - Time.now).round(1) : 'unknown'
-          log.info("LeaseManager: lease '#{name}' approaching expiry " \
-                   "(remaining=#{remaining}s renewable=#{lease[:renewable]} has_path=#{!lease[:path].nil?})")
+          log.debug("LeaseManager: lease '#{name}' approaching expiry " \
+                    "(remaining=#{remaining}s renewable=#{lease[:renewable]} has_path=#{!lease[:path].nil?})")
 
           if lease[:renewable]
             renew_lease(name, lease)
@@ -351,11 +357,17 @@ module Legion
           current_lease = @active_leases[name]
           next unless current_lease
 
-          current_lease[:lease_duration] = new_ttl if new_ttl
+          if new_ttl
+            current_lease[:lease_duration] = new_ttl
+            current_lease[:expires_at] = Time.now + new_ttl
+          end
           current_lease[:renewable] = response.renewable? if response.respond_to?(:renewable?)
-          current_lease[:expires_at] = Time.now + (new_ttl || 0)
         end
-        log.info("LeaseManager: renewed lease '#{name}' (new_ttl=#{new_ttl}s)")
+        if new_ttl
+          log.info("LeaseManager: renewed lease '#{name}' (new_ttl=#{new_ttl}s)")
+        else
+          log.warn("LeaseManager: renewed lease '#{name}' but Vault returned no lease_duration — keeping previous TTL")
+        end
 
         cached_data = @state_mutex.synchronize { @lease_cache[name] }
         if response.data && response.data != cached_data

--- a/lib/legion/crypt/vault_cluster.rb
+++ b/lib/legion/crypt/vault_cluster.rb
@@ -81,6 +81,7 @@ module Legion
       rescue ::Vault::HTTPError => e
         return true if e.message =~ /\b(429|472|473)\b/
 
+        handle_exception(e, level: :warn, operation: 'crypt.vault_cluster.cluster_healthy')
         raise
       end
 

--- a/lib/legion/crypt/vault_entity.rb
+++ b/lib/legion/crypt/vault_entity.rb
@@ -22,12 +22,12 @@ module Legion
             managed_by:            'legion'
           )
         )
-        response&.data&.dig(:id)
+        extract_id(response)
       rescue ::Vault::HTTPClientError => e
-        log.warn "Vault entity creation failed (#{canonical_name}): #{e.message}" if defined?(Legion::Logging)
+        log.warn "Vault entity creation failed (#{canonical_name}): #{e.message}"
         nil
       rescue StandardError => e
-        log.warn "Vault entity creation unexpected error (#{canonical_name}): #{e.message}" if defined?(Legion::Logging)
+        log.warn "Vault entity creation unexpected error (#{canonical_name}): #{e.message}"
         nil
       end
 
@@ -43,10 +43,10 @@ module Legion
       rescue ::Vault::HTTPClientError => e
         raise unless e.message.include?('already exists')
 
-        log.debug 'Vault entity alias already exists (idempotent)' if defined?(Legion::Logging)
+        log.debug 'Vault entity alias already exists (idempotent)'
         nil
       rescue StandardError => e
-        log.warn "Vault entity alias creation unexpected error (#{alias_name}): #{e.message}" if defined?(Legion::Logging)
+        log.warn "Vault entity alias creation unexpected error (#{alias_name}): #{e.message}"
         nil
       end
 
@@ -54,12 +54,13 @@ module Legion
       # Returns the Vault entity ID string, or nil if not found.
       def self.find_by_name(canonical_name)
         response = vault_logical.read("identity/entity/name/legion-#{canonical_name}")
-        response&.data&.dig(:id)
-      rescue ::Vault::HTTPClientError
-        # 404-class: entity does not exist yet — not an error
+        extract_id(response)
+      rescue ::Vault::HTTPClientError => e
+        # Re-log non-404 client errors as warnings before swallowing
+        log.warn "Vault entity lookup client error (#{canonical_name}): #{e.message}" unless e.message.match?(/not found|does not exist|404/i)
         nil
       rescue StandardError => e
-        log.warn "Vault entity lookup failed (#{canonical_name}): #{e.message}" if defined?(Legion::Logging)
+        log.warn "Vault entity lookup failed (#{canonical_name}): #{e.message}"
         nil
       end
 
@@ -75,6 +76,16 @@ module Legion
         end
       end
       private_class_method :vault_logical
+
+      # Extract entity ID from a Vault response, supporting both symbol and
+      # string keys (Vault SDK may return either depending on version/transport).
+      def self.extract_id(response)
+        data = response&.data
+        return nil unless data
+
+        data[:id] || data['id']
+      end
+      private_class_method :extract_id
     end
   end
 end

--- a/lib/legion/crypt/vault_entity.rb
+++ b/lib/legion/crypt/vault_entity.rb
@@ -23,11 +23,8 @@ module Legion
           )
         )
         extract_id(response)
-      rescue ::Vault::HTTPClientError => e
-        log.warn "Vault entity creation failed (#{canonical_name}): #{e.message}"
-        nil
       rescue StandardError => e
-        log.warn "Vault entity creation unexpected error (#{canonical_name}): #{e.message}"
+        handle_exception(e, level: :warn, operation: 'crypt.vault_entity.ensure_entity', canonical_name: canonical_name)
         nil
       end
 
@@ -44,11 +41,11 @@ module Legion
         if e.message.include?('already exists')
           log.debug 'Vault entity alias already exists (idempotent)'
         else
-          log.warn "Vault entity alias creation failed (#{alias_name}): #{e.message}"
+          handle_exception(e, level: :warn, operation: 'crypt.vault_entity.ensure_alias', alias_name: alias_name)
         end
         nil
       rescue StandardError => e
-        log.warn "Vault entity alias creation unexpected error (#{alias_name}): #{e.message}"
+        handle_exception(e, level: :warn, operation: 'crypt.vault_entity.ensure_alias', alias_name: alias_name)
         nil
       end
 
@@ -58,11 +55,12 @@ module Legion
         response = vault_logical.read("identity/entity/name/legion-#{canonical_name}")
         extract_id(response)
       rescue ::Vault::HTTPClientError => e
-        # Re-log non-404 client errors as warnings before swallowing
-        log.warn "Vault entity lookup client error (#{canonical_name}): #{e.message}" unless e.message.match?(/not found|does not exist|404/i)
+        unless e.message.match?(/not found|does not exist|404/i)
+          handle_exception(e, level: :warn, operation: 'crypt.vault_entity.find_by_name', canonical_name: canonical_name)
+        end
         nil
       rescue StandardError => e
-        log.warn "Vault entity lookup failed (#{canonical_name}): #{e.message}"
+        handle_exception(e, level: :warn, operation: 'crypt.vault_entity.find_by_name', canonical_name: canonical_name)
         nil
       end
 

--- a/lib/legion/crypt/vault_entity.rb
+++ b/lib/legion/crypt/vault_entity.rb
@@ -41,9 +41,11 @@ module Legion
           mount_accessor: mount_accessor
         )
       rescue ::Vault::HTTPClientError => e
-        raise unless e.message.include?('already exists')
-
-        log.debug 'Vault entity alias already exists (idempotent)'
+        if e.message.include?('already exists')
+          log.debug 'Vault entity alias already exists (idempotent)'
+        else
+          log.warn "Vault entity alias creation failed (#{alias_name}): #{e.message}"
+        end
         nil
       rescue StandardError => e
         log.warn "Vault entity alias creation unexpected error (#{alias_name}): #{e.message}"

--- a/lib/legion/crypt/vault_entity.rb
+++ b/lib/legion/crypt/vault_entity.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'legion/logging/helper'
+
+module Legion
+  module Crypt
+    module VaultEntity
+      extend Legion::Logging::Helper
+
+      # Create or lookup a Vault entity for a Legion principal.
+      # Returns the Vault entity ID string, or nil on failure.
+      def self.ensure_entity(principal_id:, canonical_name:, metadata: {})
+        existing = find_by_name(canonical_name)
+        return existing if existing
+
+        response = vault_logical.write(
+          'identity/entity',
+          name:     "legion-#{canonical_name}",
+          metadata: metadata.merge(
+            legion_principal_id:   principal_id,
+            legion_canonical_name: canonical_name,
+            managed_by:            'legion'
+          )
+        )
+        response&.data&.dig(:id)
+      rescue ::Vault::HTTPClientError => e
+        log.warn "Vault entity creation failed (#{canonical_name}): #{e.message}" if defined?(Legion::Logging)
+        nil
+      rescue StandardError => e
+        log.warn "Vault entity creation unexpected error (#{canonical_name}): #{e.message}" if defined?(Legion::Logging)
+        nil
+      end
+
+      # Create an alias linking an auth method mount to the entity.
+      # Idempotent — swallows "already exists" 4xx errors.
+      def self.ensure_alias(entity_id:, mount_accessor:, alias_name:)
+        vault_logical.write(
+          'identity/entity-alias',
+          name:           alias_name,
+          canonical_id:   entity_id,
+          mount_accessor: mount_accessor
+        )
+      rescue ::Vault::HTTPClientError => e
+        raise unless e.message.include?('already exists')
+
+        log.debug 'Vault entity alias already exists (idempotent)' if defined?(Legion::Logging)
+        nil
+      rescue StandardError => e
+        log.warn "Vault entity alias creation unexpected error (#{alias_name}): #{e.message}" if defined?(Legion::Logging)
+        nil
+      end
+
+      # Look up a Vault entity by its Legion canonical name.
+      # Returns the Vault entity ID string, or nil if not found.
+      def self.find_by_name(canonical_name)
+        response = vault_logical.read("identity/entity/name/legion-#{canonical_name}")
+        response&.data&.dig(:id)
+      rescue ::Vault::HTTPClientError
+        # 404-class: entity does not exist yet — not an error
+        nil
+      rescue StandardError => e
+        log.warn "Vault entity lookup failed (#{canonical_name}): #{e.message}" if defined?(Legion::Logging)
+        nil
+      end
+
+      # ---------------------------------------------------------------------------
+      # Private helpers
+      # ---------------------------------------------------------------------------
+
+      def self.vault_logical
+        if defined?(Legion::Crypt::LeaseManager)
+          Legion::Crypt::LeaseManager.instance.vault_logical
+        else
+          ::Vault.logical
+        end
+      end
+      private_class_method :vault_logical
+    end
+  end
+end

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.6'
+    VERSION = '1.5.7'
   end
 end

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.5'
+    VERSION = '1.5.6'
   end
 end

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe Legion::Crypt::LeaseManager do
       expect(meta[:expires_at]).to be >= (before_start + 3600)
     end
 
+    it 'stores the definition path in active_leases for reissue' do
+      manager.start(lease_definitions)
+      meta = manager.active_leases['rabbitmq']
+      expect(meta[:path]).to eq('rabbitmq/creds/legion-role')
+    end
+
+    it 'stores the path from symbol-keyed definitions' do
+      sym_defs = { rabbitmq: { path: 'rabbitmq/creds/sym-role' } }
+      manager.start(sym_defs)
+      meta = manager.active_leases[:rabbitmq]
+      expect(meta[:path]).to eq('rabbitmq/creds/sym-role')
+    end
+
     it 'handles Vault read failure gracefully without raising' do
       allow(Vault).to receive_message_chain(:logical, :read).and_raise(StandardError, 'vault unavailable')
       expect { manager.start(lease_definitions) }.not_to raise_error
@@ -530,6 +543,106 @@ RSpec.describe Legion::Crypt::LeaseManager do
           settings_refs: []
         )
       end.not_to raise_error
+    end
+  end
+
+  describe '#renew_lease with static leases' do
+    let(:fresh_response) do
+      double('Vault::Secret',
+             data:           { username: 'fresh_user', password: 'fresh_pass' },
+             lease_id:       'rabbitmq/creds/legion-role/fresh789',
+             lease_duration: 3600,
+             renewable?:     true)
+    end
+
+    before { manager.start(lease_definitions) }
+
+    it 'falls back to reissue when sys.renew fails and path is available' do
+      sys_double = instance_double(Vault::Sys)
+      allow(Vault).to receive(:sys).and_return(sys_double)
+      allow(sys_double).to receive(:renew).and_raise(StandardError, 'permission denied')
+      allow(Vault).to receive_message_chain(:logical, :read).and_return(fresh_response)
+
+      manager.send(:renew_lease, 'rabbitmq', manager.active_leases['rabbitmq'])
+
+      expect(manager.fetch('rabbitmq', :username)).to eq('fresh_user')
+    end
+
+    it 'updates credentials after successful reissue fallback' do
+      sys_double = instance_double(Vault::Sys)
+      allow(Vault).to receive(:sys).and_return(sys_double)
+      allow(sys_double).to receive(:renew).and_raise(StandardError, 'expired')
+      allow(Vault).to receive_message_chain(:logical, :read).and_return(fresh_response)
+
+      manager.send(:renew_lease, 'rabbitmq', manager.active_leases['rabbitmq'])
+
+      expect(manager.active_leases['rabbitmq'][:lease_id]).to eq('rabbitmq/creds/legion-role/fresh789')
+    end
+  end
+
+  describe '#renew_approaching_leases with non-renewable pathless lease' do
+    let(:non_renewable_response) do
+      double('Vault::Secret',
+             data:           { username: 'user', password: 'pass' },
+             lease_id:       'some/lease/abc',
+             lease_duration: 100,
+             renewable?:     false)
+    end
+
+    it 'does not raise for a non-renewable lease without a path' do
+      allow(Vault).to receive_message_chain(:logical, :read).and_return(non_renewable_response)
+      manager.start({ 'legacy' => { 'path' => 'some/creds/role' } })
+      # Remove the path to simulate the old bug
+      manager.active_leases['legacy'].delete(:path)
+      manager.active_leases['legacy'][:expires_at] = Time.now + 10
+
+      expect { manager.send(:renew_approaching_leases) }.not_to raise_error
+    end
+  end
+
+  describe '#trigger_reconnect' do
+    context 'when name is :rabbitmq' do
+      it 'calls Transport::Connection.force_reconnect' do
+        transport_conn = double('Legion::Transport::Connection')
+        stub_const('Legion::Transport::Connection', transport_conn)
+        expect(transport_conn).to receive(:force_reconnect)
+        manager.send(:trigger_reconnect, :rabbitmq)
+      end
+    end
+
+    context 'when name is :postgresql' do
+      it 'calls Data.reconnect when available' do
+        data_mod = double('Legion::Data')
+        stub_const('Legion::Data', data_mod)
+        allow(data_mod).to receive(:respond_to?).with(:reconnect).and_return(true)
+        expect(data_mod).to receive(:reconnect)
+        manager.send(:trigger_reconnect, :postgresql)
+      end
+
+      it 'skips when Data does not respond to reconnect' do
+        data_mod = double('Legion::Data')
+        stub_const('Legion::Data', data_mod)
+        allow(data_mod).to receive(:respond_to?).with(:reconnect).and_return(false)
+        expect(data_mod).not_to receive(:reconnect)
+        manager.send(:trigger_reconnect, :postgresql)
+      end
+    end
+
+    context 'when name is :redis' do
+      it 'calls Cache.reconnect when available' do
+        cache_mod = double('Legion::Cache')
+        stub_const('Legion::Cache', cache_mod)
+        allow(cache_mod).to receive(:respond_to?).with(:reconnect).and_return(true)
+        expect(cache_mod).to receive(:reconnect)
+        manager.send(:trigger_reconnect, :redis)
+      end
+    end
+
+    it 'handles reconnect errors gracefully' do
+      transport_conn = double('Legion::Transport::Connection')
+      stub_const('Legion::Transport::Connection', transport_conn)
+      allow(transport_conn).to receive(:force_reconnect).and_raise(StandardError, 'connection refused')
+      expect { manager.send(:trigger_reconnect, :rabbitmq) }.not_to raise_error
     end
   end
 

--- a/spec/legion/vault_entity_spec.rb
+++ b/spec/legion/vault_entity_spec.rb
@@ -270,14 +270,13 @@ RSpec.describe Legion::Crypt::VaultEntity do
           .and_raise(err)
       end
 
-      it 're-raises the error' do
-        expect do
-          described_class.ensure_alias(
-            entity_id:      entity_id,
-            mount_accessor: mount_accessor,
-            alias_name:     alias_name
-          )
-        end.to raise_error(Vault::HTTPClientError, 'permission denied')
+      it 'returns nil without raising (non-fatal)' do
+        result = described_class.ensure_alias(
+          entity_id:      entity_id,
+          mount_accessor: mount_accessor,
+          alias_name:     alias_name
+        )
+        expect(result).to be_nil
       end
     end
 

--- a/spec/legion/vault_entity_spec.rb
+++ b/spec/legion/vault_entity_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Legion::Crypt::VaultEntity do
     double('Vault::Secret', data: { id: entity_id, name: "legion-#{canonical_name}" })
   end
 
+  let(:entity_response_string_keys) do
+    double('Vault::Secret', data: { 'id' => entity_id, 'name' => "legion-#{canonical_name}" })
+  end
+
   let(:alias_response) do
     double('Vault::Secret', data: { id: 'alias-xyz-456' })
   end
@@ -148,6 +152,26 @@ RSpec.describe Legion::Crypt::VaultEntity do
           canonical_name: canonical_name
         )
         expect(result).to be_nil
+      end
+    end
+
+    context 'when write response returns string-keyed data' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(nil)
+
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity', anything)
+          .and_return(entity_response_string_keys)
+      end
+
+      it 'returns the entity ID from string-keyed response' do
+        result = described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name
+        )
+        expect(result).to eq(entity_id)
       end
     end
 
@@ -345,6 +369,32 @@ RSpec.describe Legion::Crypt::VaultEntity do
       end
 
       it 'returns nil' do
+        result = described_class.find_by_name(canonical_name)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when response returns string-keyed data' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(entity_response_string_keys)
+      end
+
+      it 'returns the entity ID from string-keyed response' do
+        result = described_class.find_by_name(canonical_name)
+        expect(result).to eq(entity_id)
+      end
+    end
+
+    context 'when Vault raises a non-404 HTTPClientError' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_raise(Vault::HTTPClientError, 'permission denied')
+      end
+
+      it 'returns nil without raising' do
         result = described_class.find_by_name(canonical_name)
         expect(result).to be_nil
       end

--- a/spec/legion/vault_entity_spec.rb
+++ b/spec/legion/vault_entity_spec.rb
@@ -1,0 +1,382 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/crypt/vault_entity'
+
+RSpec.describe Legion::Crypt::VaultEntity do
+  let(:vault_logical)   { instance_double('Vault::Logical') }
+  let(:lease_manager)   { instance_double('Legion::Crypt::LeaseManager') }
+
+  let(:principal_id)    { 'user@example.com' }
+  let(:canonical_name)  { 'user-example-com' }
+  let(:entity_id)       { 'ent-abc-123' }
+  let(:mount_accessor)  { 'auth_jwt_abc123' }
+  let(:alias_name)      { 'user@example.com' }
+
+  let(:entity_response) do
+    double('Vault::Secret', data: { id: entity_id, name: "legion-#{canonical_name}" })
+  end
+
+  let(:alias_response) do
+    double('Vault::Secret', data: { id: 'alias-xyz-456' })
+  end
+
+  before do
+    stub_const('Vault::HTTPClientError', Class.new(StandardError))
+
+    allow(Legion::Crypt::LeaseManager).to receive(:instance).and_return(lease_manager)
+    allow(lease_manager).to receive(:vault_logical).and_return(vault_logical)
+
+    allow(vault_logical).to receive(:read).and_return(nil)
+    allow(vault_logical).to receive(:write).and_return(nil)
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '.ensure_entity' do
+    context 'when no entity exists yet' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(nil)
+
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity', anything)
+          .and_return(entity_response)
+      end
+
+      it 'creates an entity and returns its ID' do
+        result = described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name
+        )
+        expect(result).to eq(entity_id)
+      end
+
+      it 'writes to identity/entity with the legion- prefix' do
+        expect(vault_logical).to receive(:write).with(
+          'identity/entity',
+          hash_including(name: "legion-#{canonical_name}")
+        ).and_return(entity_response)
+
+        described_class.ensure_entity(principal_id: principal_id, canonical_name: canonical_name)
+      end
+
+      it 'includes standard managed_by metadata' do
+        expect(vault_logical).to receive(:write).with(
+          'identity/entity',
+          hash_including(
+            metadata: hash_including(
+              managed_by:            'legion',
+              legion_principal_id:   principal_id,
+              legion_canonical_name: canonical_name
+            )
+          )
+        ).and_return(entity_response)
+
+        described_class.ensure_entity(principal_id: principal_id, canonical_name: canonical_name)
+      end
+
+      it 'merges caller-supplied metadata with standard metadata' do
+        expect(vault_logical).to receive(:write).with(
+          'identity/entity',
+          hash_including(
+            metadata: hash_including(
+              custom_key:          'custom_value',
+              legion_principal_id: principal_id,
+              managed_by:          'legion'
+            )
+          )
+        ).and_return(entity_response)
+
+        described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name,
+          metadata:       { custom_key: 'custom_value' }
+        )
+      end
+    end
+
+    context 'when entity already exists' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(entity_response)
+      end
+
+      it 'returns the existing entity ID without creating a new one' do
+        expect(vault_logical).not_to receive(:write).with('identity/entity', anything)
+
+        result = described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name
+        )
+        expect(result).to eq(entity_id)
+      end
+    end
+
+    context 'when Vault raises HTTPClientError on write' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(nil)
+
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity', anything)
+          .and_raise(Vault::HTTPClientError, 'permission denied')
+      end
+
+      it 'returns nil instead of raising' do
+        result = described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name
+        )
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when Vault raises an unexpected StandardError' do
+      before do
+        allow(vault_logical).to receive(:read).and_return(nil)
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity', anything)
+          .and_raise(StandardError, 'network timeout')
+      end
+
+      it 'returns nil instead of raising' do
+        result = described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name
+        )
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when write response has no data' do
+      before do
+        allow(vault_logical).to receive(:read).and_return(nil)
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity', anything)
+          .and_return(double('Vault::Secret', data: nil))
+      end
+
+      it 'returns nil' do
+        result = described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name
+        )
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when write returns nil response' do
+      before do
+        allow(vault_logical).to receive(:read).and_return(nil)
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity', anything)
+          .and_return(nil)
+      end
+
+      it 'returns nil' do
+        result = described_class.ensure_entity(
+          principal_id:   principal_id,
+          canonical_name: canonical_name
+        )
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '.ensure_alias' do
+    context 'when alias does not exist' do
+      before do
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity-alias', anything)
+          .and_return(alias_response)
+      end
+
+      it 'writes to identity/entity-alias and returns the response' do
+        result = described_class.ensure_alias(
+          entity_id:      entity_id,
+          mount_accessor: mount_accessor,
+          alias_name:     alias_name
+        )
+        expect(result).to eq(alias_response)
+      end
+
+      it 'passes the correct params to Vault' do
+        expect(vault_logical).to receive(:write).with(
+          'identity/entity-alias',
+          name:           alias_name,
+          canonical_id:   entity_id,
+          mount_accessor: mount_accessor
+        ).and_return(alias_response)
+
+        described_class.ensure_alias(
+          entity_id:      entity_id,
+          mount_accessor: mount_accessor,
+          alias_name:     alias_name
+        )
+      end
+    end
+
+    context 'when alias already exists (idempotent)' do
+      before do
+        err = Vault::HTTPClientError.new('alias already exists for the combination of mount and alias name')
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity-alias', anything)
+          .and_raise(err)
+      end
+
+      it 'returns nil without raising' do
+        result = described_class.ensure_alias(
+          entity_id:      entity_id,
+          mount_accessor: mount_accessor,
+          alias_name:     alias_name
+        )
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when Vault raises a different HTTPClientError' do
+      before do
+        err = Vault::HTTPClientError.new('permission denied')
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity-alias', anything)
+          .and_raise(err)
+      end
+
+      it 're-raises the error' do
+        expect do
+          described_class.ensure_alias(
+            entity_id:      entity_id,
+            mount_accessor: mount_accessor,
+            alias_name:     alias_name
+          )
+        end.to raise_error(Vault::HTTPClientError, 'permission denied')
+      end
+    end
+
+    context 'when Vault raises an unexpected StandardError' do
+      before do
+        allow(vault_logical).to receive(:write)
+          .with('identity/entity-alias', anything)
+          .and_raise(StandardError, 'connection reset')
+      end
+
+      it 'returns nil without raising' do
+        result = described_class.ensure_alias(
+          entity_id:      entity_id,
+          mount_accessor: mount_accessor,
+          alias_name:     alias_name
+        )
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '.find_by_name' do
+    context 'when entity exists' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(entity_response)
+      end
+
+      it 'returns the entity ID' do
+        result = described_class.find_by_name(canonical_name)
+        expect(result).to eq(entity_id)
+      end
+
+      it 'reads the legion- prefixed path' do
+        expect(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(entity_response)
+
+        described_class.find_by_name(canonical_name)
+      end
+    end
+
+    context 'when entity does not exist (nil response)' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(nil)
+      end
+
+      it 'returns nil' do
+        result = described_class.find_by_name(canonical_name)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when Vault raises HTTPClientError (404)' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_raise(Vault::HTTPClientError, 'entity not found')
+      end
+
+      it 'returns nil without raising' do
+        result = described_class.find_by_name(canonical_name)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when Vault raises an unexpected StandardError' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_raise(StandardError, 'timeout')
+      end
+
+      it 'returns nil without raising' do
+        result = described_class.find_by_name(canonical_name)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when response data has no id field' do
+      before do
+        allow(vault_logical).to receive(:read)
+          .with("identity/entity/name/legion-#{canonical_name}")
+          .and_return(double('Vault::Secret', data: { name: 'legion-foo' }))
+      end
+
+      it 'returns nil' do
+        result = described_class.find_by_name(canonical_name)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe 'vault_logical resolution' do
+    context 'when LeaseManager is defined' do
+      it 'delegates to LeaseManager.instance.vault_logical' do
+        expect(lease_manager).to receive(:vault_logical).and_return(vault_logical)
+        allow(vault_logical).to receive(:read).and_return(nil)
+
+        described_class.find_by_name(canonical_name)
+      end
+    end
+
+    context 'when LeaseManager is not defined' do
+      before do
+        hide_const('Legion::Crypt::LeaseManager')
+
+        stub_const('Vault', Module.new)
+        stub_const('Vault::HTTPClientError', Class.new(StandardError))
+        allow(Vault).to receive(:logical).and_return(vault_logical)
+        allow(vault_logical).to receive(:read).and_return(nil)
+      end
+
+      it 'falls back to ::Vault.logical' do
+        expect(Vault).to receive(:logical).and_return(vault_logical)
+
+        described_class.find_by_name(canonical_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Legion::Crypt::VaultEntity` module (`lib/legion/crypt/vault_entity.rb`) implementing Phase 7 Vault entity tracking from the design doc (`docs/plans/2026-04-07-vault-rbac-integration-design.md` §4)
- `ensure_entity` — create or find a Vault entity for a Legion principal; entity names prefixed `legion-` to avoid collision; metadata includes `legion_principal_id`, `legion_canonical_name`, `managed_by: 'legion'`; returns entity ID or nil (non-fatal)
- `ensure_alias` — create an entity alias linking an auth method mount to the entity; idempotent (`already exists` 4xx swallowed, other 4xx re-raise)
- `find_by_name` — lookup entity by Legion canonical name via `identity/entity/name/legion-{name}`
- All operations are non-fatal — rescue + log warn on failure; request/boot flow is never blocked
- Delegates Vault API calls to `LeaseManager.instance.vault_logical` (public delegator, NOT the private `.logical`); falls back to `::Vault.logical` when LeaseManager is absent
- Does NOT use `login!` (which mutates global `::Vault.token`) — entity tracking is request-time only in Phase 7

## Test plan

- [ ] `bundle exec rspec spec/legion/vault_entity_spec.rb` — 30+ examples covering create-new, find-existing, idempotent alias, HTTPClientError dedup, unexpected errors, nil/empty responses, and LeaseManager fallback
- [ ] Full suite green (no regressions)
- [ ] `bundle exec rubocop` — 0 offenses