### PR TITLE
fix: handle_exception respects level: kwarg (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.5.10] - 2026-04-19
+
+### Fixed
+- `handle_exception` now passes the caller's `level:` kwarg through to `Legion::Logging.log_exception` instead of always defaulting to `:error` — optional missing-gem `LoadError`s log at the intended level (e.g. `:debug`). Fixes LegionIO/LegionIO#155
+- `exception_log_message` now suppresses backtrace for `:debug` level — previously only suppressed when the backtrace was empty
+
 ## [1.5.9] - 2026-04-10
 
 ### Fixed

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.9'
+    VERSION = '1.5.10'
   end
 end

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -52,7 +52,7 @@ module Legion
         message = exception_log_message(exception, level: level, **opts) # rubocop:disable Style/ArgumentsForwarding
 
         if logging_supports?(:log_exception)
-          Legion::Logging.log_exception(exception, lex: 'crypt', component_type: :helper)
+          Legion::Logging.log_exception(exception, level: level, lex: 'crypt', component_type: :helper)
           return
         end
         if logging_supports?(level)
@@ -88,7 +88,7 @@ module Legion
         detail_suffix = details.empty? ? '' : " (#{details.join(' ')})"
         backtrace = Array(exception.backtrace).first(10).join("\n")
         base = "#{prefix}#{exception.class}: #{exception.message}#{detail_suffix}"
-        return base if backtrace.empty? && level == :debug
+        return base if backtrace.empty? || level == :debug
         return base if backtrace.empty?
 
         "#{base}\n#{backtrace}"

--- a/spec/legion/cluster_secret_spec.rb
+++ b/spec/legion/cluster_secret_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Legion::Crypt::ClusterSecret do
       logging = double('Legion::Logging')
       stub_const('Legion::Logging', logging)
       allow(logging).to receive(:respond_to?).with(:log_exception).and_return(true)
-      expect(logging).to receive(:log_exception).with(instance_of(StandardError), lex: 'crypt', component_type: :helper)
+      expect(logging).to receive(:log_exception).with(instance_of(StandardError), level: :error, lex: 'crypt', component_type: :helper)
       @cs.from_transport
     end
 
@@ -225,7 +225,7 @@ RSpec.describe Legion::Crypt::ClusterSecret do
       logging = double('Legion::Logging')
       stub_const('Legion::Logging', logging)
       allow(logging).to receive(:respond_to?).with(:log_exception).and_return(true)
-      expect(logging).to receive(:log_exception).with(instance_of(StandardError), lex: 'crypt', component_type: :helper)
+      expect(logging).to receive(:log_exception).with(instance_of(StandardError), level: :error, lex: 'crypt', component_type: :helper)
       @cs.cs
     end
 

--- a/spec/legion/vault_spec.rb
+++ b/spec/legion/vault_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Legion::Crypt::Vault do
       allow(logging).to receive(:respond_to?).with(:info).and_return(true)
       allow(logging).to receive(:respond_to?).with(:log_exception).and_return(true)
       allow(logging).to receive(:info)
-      expect(logging).to receive(:log_exception).with(instance_of(StandardError), lex: 'crypt', component_type: :helper)
+      expect(logging).to receive(:log_exception).with(instance_of(StandardError), level: :error, lex: 'crypt', component_type: :helper)
       @vault.connect_vault
     end
 


### PR DESCRIPTION
## Summary

- Pass caller's `level:` kwarg through to `Legion::Logging.log_exception` in `handle_exception` instead of silently dropping it (which caused all exceptions to log at `:error` regardless of the caller's intent)
- Fix `exception_log_message` to suppress backtrace for `:debug` level (changed `&&` to `||` so debug-level messages never include stack traces, not just when backtrace is empty)
- Update specs to expect the new `level: :error` kwarg in `log_exception` calls

Fixes LegionIO/LegionIO#155

## Test plan

- [x] `bundle exec rspec` — 630 examples, 0 failures
- [x] `bundle exec rubocop -A` — 0 offenses