### PR TITLE
fix: PostgreSQL credential rotation with fresh creds and callback registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## [Unreleased]
 
-## [1.5.10] - 2026-04-19
+## [1.5.10] - 2026-04-21
 
 ### Fixed
 - `handle_exception` now passes the caller's `level:` kwarg through to `Legion::Logging.log_exception` instead of always defaulting to `:error` — optional missing-gem `LoadError`s log at the intended level (e.g. `:debug`). Fixes LegionIO/LegionIO#155
 - `exception_log_message` now suppresses backtrace for `:debug` level — previously only suppressed when the backtrace was empty
+- `LeaseManager#on_credential_rotation` input validation: now raises `ArgumentError` for nil blocks, non-String/Symbol names, and empty names
+- `LeaseManager#trigger_reconnect` callback execution order: rotation callbacks now always execute even if reconnect steps fail or dependencies are missing
 
+### Added
+- `LeaseManager#on_credential_rotation` comprehensive input validation with clear error messages
+- Callback execution resilience: callbacks are invoked even when `Transport::Connection.force_reconnect`, `Data::Connection.reconnect_with_fresh_creds`, or `Cache.restart` fail
+- Test coverage for callback execution when reconnect failures occur and when service dependencies are missing
 ## [1.5.9] - 2026-04-10
 
 ### Fixed

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -16,6 +16,7 @@ module Legion
         @lease_cache = {}
         @active_leases = {}
         @refs = {}
+        @rotation_callbacks = {}
         @running = false
         @renewal_thread = nil
         @state_mutex = Mutex.new
@@ -109,6 +110,13 @@ module Legion
 
       def vault_sys
         sys
+      end
+
+      def on_credential_rotation(name, &block)
+        @state_mutex.synchronize do
+          @rotation_callbacks[name.to_sym] ||= []
+          @rotation_callbacks[name.to_sym] << block
+        end
       end
 
       def reissue_all
@@ -234,6 +242,7 @@ module Legion
           @lease_cache.clear
           @active_leases.clear
           @refs.clear
+          @rotation_callbacks.clear
           @vault_client = nil
           @renewal_thread = nil
         end
@@ -466,10 +475,14 @@ module Legion
           Legion::Transport::Connection.force_reconnect
           log.info("LeaseManager: triggered transport reconnect after '#{name}' reissue")
         when :postgresql
-          return unless defined?(Legion::Data::Connection) && Legion::Data::Connection.sequel
+          return unless defined?(Legion::Data::Connection)
 
-          Legion::Data::Connection.sequel.disconnect
-          Legion::Data::Connection.sequel.test_connection
+          if Legion::Data::Connection.respond_to?(:reconnect_with_fresh_creds)
+            Legion::Data::Connection.reconnect_with_fresh_creds
+          elsif Legion::Data::Connection.sequel
+            Legion::Data::Connection.sequel.disconnect
+            Legion::Data::Connection.sequel.test_connection
+          end
           log.info("LeaseManager: triggered data pool reconnect after '#{name}' reissue")
         when :redis
           return unless defined?(Legion::Cache)
@@ -481,9 +494,27 @@ module Legion
           end
           log.info("LeaseManager: triggered cache reconnect after '#{name}' reissue")
         end
+
+        invoke_rotation_callbacks(name)
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
         log.warn("LeaseManager: reconnect for '#{name}' failed: #{e.message}")
+      end
+
+      def invoke_rotation_callbacks(name)
+        callbacks, data = @state_mutex.synchronize do
+          cbs = @rotation_callbacks[name.to_sym]&.dup || []
+          d = @lease_cache[name]&.dup || @lease_cache[name.to_s]&.dup
+          [cbs, d]
+        end
+        return if callbacks.empty?
+
+        callbacks.each do |cb|
+          cb.call(data)
+        rescue StandardError => e
+          handle_exception(e, level: :warn, operation: 'crypt.lease_manager.rotation_callback', lease_name: name)
+          log.warn("LeaseManager: rotation callback for '#{name}' failed: #{e.message}")
+        end
       end
 
       def running?

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -113,6 +113,13 @@ module Legion
       end
 
       def on_credential_rotation(name, &block)
+        raise ArgumentError, 'Block is required' if block.nil?
+
+        raise ArgumentError, 'Name must be a String or Symbol' unless name.is_a?(String) || name.is_a?(Symbol)
+
+        name_str = name.to_s.strip
+        raise ArgumentError, 'Name cannot be empty' if name_str.empty?
+
         @state_mutex.synchronize do
           @rotation_callbacks[name.to_sym] ||= []
           @rotation_callbacks[name.to_sym] << block
@@ -468,37 +475,44 @@ module Legion
 
       def trigger_reconnect(name)
         name = name.to_sym if name.respond_to?(:to_sym)
-        case name
-        when :rabbitmq
-          return unless defined?(Legion::Transport::Connection)
 
-          Legion::Transport::Connection.force_reconnect
-          log.info("LeaseManager: triggered transport reconnect after '#{name}' reissue")
-        when :postgresql
-          return unless defined?(Legion::Data::Connection)
-
-          if Legion::Data::Connection.respond_to?(:reconnect_with_fresh_creds)
-            Legion::Data::Connection.reconnect_with_fresh_creds
-          elsif Legion::Data::Connection.sequel
-            Legion::Data::Connection.sequel.disconnect
-            Legion::Data::Connection.sequel.test_connection
+        begin
+          case name
+          when :rabbitmq
+            if defined?(Legion::Transport::Connection)
+              Legion::Transport::Connection.force_reconnect
+              log.info("LeaseManager: triggered transport reconnect after '#{name}' reissue")
+            end
+          when :postgresql
+            if defined?(Legion::Data::Connection)
+              if Legion::Data::Connection.respond_to?(:reconnect_with_fresh_creds)
+                Legion::Data::Connection.reconnect_with_fresh_creds
+              elsif Legion::Data::Connection.sequel
+                Legion::Data::Connection.sequel.disconnect
+                Legion::Data::Connection.sequel.test_connection
+              end
+              log.info("LeaseManager: triggered data pool reconnect after '#{name}' reissue")
+            end
+          when :redis
+            if defined?(Legion::Cache)
+              if Legion::Cache.respond_to?(:restart)
+                Legion::Cache.restart
+              elsif Legion::Cache.respond_to?(:reconnect)
+                Legion::Cache.reconnect
+              end
+              log.info("LeaseManager: triggered cache reconnect after '#{name}' reissue")
+            end
           end
-          log.info("LeaseManager: triggered data pool reconnect after '#{name}' reissue")
-        when :redis
-          return unless defined?(Legion::Cache)
-
-          if Legion::Cache.respond_to?(:restart)
-            Legion::Cache.restart
-          elsif Legion::Cache.respond_to?(:reconnect)
-            Legion::Cache.reconnect
-          end
-          log.info("LeaseManager: triggered cache reconnect after '#{name}' reissue")
+        rescue StandardError => e
+          handle_exception(e, level: :warn, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
+          log.warn("LeaseManager: reconnect for '#{name}' failed: #{e.message}")
         end
 
+        # Always attempt to invoke callbacks even if reconnect steps fail
         invoke_rotation_callbacks(name)
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
-        log.warn("LeaseManager: reconnect for '#{name}' failed: #{e.message}")
+        log.warn("LeaseManager: failed to trigger reconnect for '#{name}': #{e.message}")
       end
 
       def invoke_rotation_callbacks(name)

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -694,6 +694,36 @@ RSpec.describe Legion::Crypt::LeaseManager do
       callbacks = manager.instance_variable_get(:@rotation_callbacks)
       expect(callbacks[:postgresql].size).to eq(1)
     end
+
+    describe 'input validation' do
+      it 'raises ArgumentError when block is nil' do
+        expect { manager.on_credential_rotation(:postgresql) }.to raise_error(ArgumentError, 'Block is required')
+      end
+
+      it 'raises ArgumentError when name is not a String or Symbol' do
+        expect { manager.on_credential_rotation(123) { |_data| } }.to raise_error(ArgumentError, 'Name must be a String or Symbol')
+        expect { manager.on_credential_rotation([]) { |_data| } }.to raise_error(ArgumentError, 'Name must be a String or Symbol')
+        expect { manager.on_credential_rotation({}) { |_data| } }.to raise_error(ArgumentError, 'Name must be a String or Symbol')
+      end
+
+      it 'raises ArgumentError when name is empty string' do
+        expect { manager.on_credential_rotation('') { |_data| } }.to raise_error(ArgumentError, 'Name cannot be empty')
+      end
+
+      it 'raises ArgumentError when name is whitespace only' do
+        expect { manager.on_credential_rotation('   ') { |_data| } }.to raise_error(ArgumentError, 'Name cannot be empty')
+      end
+
+      it 'accepts valid string names' do
+        expect { manager.on_credential_rotation('postgresql') { |_data| } }.not_to raise_error
+        expect { manager.on_credential_rotation('redis') { |_data| } }.not_to raise_error
+      end
+
+      it 'accepts valid symbol names' do
+        expect { manager.on_credential_rotation(:postgresql) { |_data| } }.not_to raise_error
+        expect { manager.on_credential_rotation(:redis) { |_data| } }.not_to raise_error
+      end
+    end
   end
 
   describe 'rotation callback invocation via trigger_reconnect' do
@@ -765,6 +795,65 @@ RSpec.describe Legion::Crypt::LeaseManager do
 
       manager.send(:trigger_reconnect, :custom_db)
       expect(received_data).to eq({ host: 'db.example.com' })
+    end
+
+    describe 'callback execution resilience' do
+      it 'invokes callbacks even when Transport::Connection.force_reconnect fails' do
+        received_data = nil
+        manager.on_credential_rotation(:rabbitmq) { |data| received_data = data }
+
+        manager.start(lease_definitions)
+
+        transport_conn = double('Legion::Transport::Connection')
+        stub_const('Legion::Transport::Connection', transport_conn)
+        allow(transport_conn).to receive(:force_reconnect).and_raise(StandardError, 'connection failed')
+
+        manager.send(:trigger_reconnect, :rabbitmq)
+        expect(received_data).to eq({ username: 'rabbit_user', password: 'rabbit_pass' })
+      end
+
+      it 'invokes callbacks even when Data::Connection reconnect fails' do
+        received_data = nil
+        manager.on_credential_rotation(:postgresql) { |data| received_data = data }
+
+        # Populate cache manually
+        manager.instance_variable_get(:@lease_cache)[:postgresql] = { username: 'pg_user', password: 'pg_pass' }
+
+        connection_mod = double('Legion::Data::Connection')
+        stub_const('Legion::Data::Connection', connection_mod)
+        allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(true)
+        allow(connection_mod).to receive(:reconnect_with_fresh_creds).and_raise(StandardError, 'pg connection failed')
+
+        manager.send(:trigger_reconnect, :postgresql)
+        expect(received_data).to eq({ username: 'pg_user', password: 'pg_pass' })
+      end
+
+      it 'invokes callbacks even when Cache.restart fails' do
+        received_data = nil
+        manager.on_credential_rotation(:redis) { |data| received_data = data }
+
+        # Populate cache manually
+        manager.instance_variable_get(:@lease_cache)[:redis] = { password: 'redis_pass' }
+
+        cache_mod = double('Legion::Cache')
+        stub_const('Legion::Cache', cache_mod)
+        allow(cache_mod).to receive(:respond_to?).with(:restart).and_return(true)
+        allow(cache_mod).to receive(:restart).and_raise(StandardError, 'cache restart failed')
+
+        manager.send(:trigger_reconnect, :redis)
+        expect(received_data).to eq({ password: 'redis_pass' })
+      end
+
+      it 'invokes callbacks when service dependencies are missing' do
+        received_data = nil
+        manager.on_credential_rotation(:rabbitmq) { |data| received_data = data }
+
+        manager.start(lease_definitions)
+
+        # Transport::Connection not defined - should skip reconnect but still invoke callbacks
+        manager.send(:trigger_reconnect, :rabbitmq)
+        expect(received_data).to eq({ username: 'rabbit_user', password: 'rabbit_pass' })
+      end
     end
   end
 

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -637,11 +637,134 @@ RSpec.describe Legion::Crypt::LeaseManager do
       end
     end
 
+    context 'when name is :postgresql and reconnect_with_fresh_creds is available' do
+      it 'prefers reconnect_with_fresh_creds over disconnect/test_connection' do
+        connection_mod = double('Legion::Data::Connection')
+        stub_const('Legion::Data::Connection', connection_mod)
+        allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(true)
+        expect(connection_mod).to receive(:reconnect_with_fresh_creds)
+        expect(connection_mod).not_to receive(:sequel)
+        manager.send(:trigger_reconnect, :postgresql)
+      end
+    end
+
+    context 'when name is :postgresql and reconnect_with_fresh_creds is not available' do
+      it 'falls back to sequel disconnect/test_connection' do
+        sequel_db = double('Sequel::Database')
+        connection_mod = double('Legion::Data::Connection', sequel: sequel_db)
+        stub_const('Legion::Data::Connection', connection_mod)
+        allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(false)
+        expect(sequel_db).to receive(:disconnect)
+        expect(sequel_db).to receive(:test_connection)
+        manager.send(:trigger_reconnect, :postgresql)
+      end
+
+      it 'skips when sequel is nil and reconnect_with_fresh_creds is not available' do
+        connection_mod = double('Legion::Data::Connection', sequel: nil)
+        stub_const('Legion::Data::Connection', connection_mod)
+        allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(false)
+        expect { manager.send(:trigger_reconnect, :postgresql) }.not_to raise_error
+      end
+    end
+
     it 'handles reconnect errors gracefully' do
       transport_conn = double('Legion::Transport::Connection')
       stub_const('Legion::Transport::Connection', transport_conn)
       allow(transport_conn).to receive(:force_reconnect).and_raise(StandardError, 'connection refused')
       expect { manager.send(:trigger_reconnect, :rabbitmq) }.not_to raise_error
+    end
+  end
+
+  describe '#on_credential_rotation' do
+    it 'stores a callback for a lease name' do
+      manager.on_credential_rotation(:postgresql) { |_data| }
+      callbacks = manager.instance_variable_get(:@rotation_callbacks)
+      expect(callbacks[:postgresql].size).to eq(1)
+    end
+
+    it 'allows multiple callbacks for the same lease name' do
+      manager.on_credential_rotation(:postgresql) { |_data| 'cb1' }
+      manager.on_credential_rotation(:postgresql) { |_data| 'cb2' }
+      callbacks = manager.instance_variable_get(:@rotation_callbacks)
+      expect(callbacks[:postgresql].size).to eq(2)
+    end
+
+    it 'converts string names to symbols' do
+      manager.on_credential_rotation('postgresql') { |_data| }
+      callbacks = manager.instance_variable_get(:@rotation_callbacks)
+      expect(callbacks[:postgresql].size).to eq(1)
+    end
+  end
+
+  describe 'rotation callback invocation via trigger_reconnect' do
+    it 'invokes registered callbacks with lease data' do
+      received_data = nil
+      manager.on_credential_rotation(:rabbitmq) { |data| received_data = data }
+
+      # Populate lease cache so callback receives data
+      manager.start(lease_definitions)
+
+      transport_conn = double('Legion::Transport::Connection')
+      stub_const('Legion::Transport::Connection', transport_conn)
+      allow(transport_conn).to receive(:force_reconnect)
+
+      manager.send(:trigger_reconnect, :rabbitmq)
+      expect(received_data).to eq({ username: 'rabbit_user', password: 'rabbit_pass' })
+    end
+
+    it 'invokes all registered callbacks for the lease' do
+      call_count = 0
+      manager.on_credential_rotation(:rabbitmq) { |_data| call_count += 1 }
+      manager.on_credential_rotation(:rabbitmq) { |_data| call_count += 1 }
+
+      manager.start(lease_definitions)
+
+      transport_conn = double('Legion::Transport::Connection')
+      stub_const('Legion::Transport::Connection', transport_conn)
+      allow(transport_conn).to receive(:force_reconnect)
+
+      manager.send(:trigger_reconnect, :rabbitmq)
+      expect(call_count).to eq(2)
+    end
+
+    it 'continues invoking remaining callbacks when one raises' do
+      results = []
+      manager.on_credential_rotation(:rabbitmq) { |_data| raise StandardError, 'boom' }
+      manager.on_credential_rotation(:rabbitmq) { |_data| results << 'second_ran' }
+
+      manager.start(lease_definitions)
+
+      transport_conn = double('Legion::Transport::Connection')
+      stub_const('Legion::Transport::Connection', transport_conn)
+      allow(transport_conn).to receive(:force_reconnect)
+
+      manager.send(:trigger_reconnect, :rabbitmq)
+      expect(results).to eq(['second_ran'])
+    end
+
+    it 'does not invoke callbacks for a different lease name' do
+      called = false
+      manager.on_credential_rotation(:postgresql) { |_data| called = true }
+
+      manager.start(lease_definitions)
+
+      transport_conn = double('Legion::Transport::Connection')
+      stub_const('Legion::Transport::Connection', transport_conn)
+      allow(transport_conn).to receive(:force_reconnect)
+
+      manager.send(:trigger_reconnect, :rabbitmq)
+      expect(called).to be(false)
+    end
+
+    it 'invokes callbacks for unrecognized lease names (no case match)' do
+      received_data = nil
+      manager.on_credential_rotation(:custom_db) { |data| received_data = data }
+
+      # Manually populate the cache for an unrecognized name
+      manager.instance_variable_get(:@lease_cache)[:custom_db] = { host: 'db.example.com' }
+
+      manager.send(:trigger_reconnect, :custom_db)
+      expect(received_data).to eq({ host: 'db.example.com' })
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes stale credential usage after Vault rotates database credentials (common after VPN reconnect or system sleep). Adds an extensible callback system for credential rotation events.

- **Smart reconnection**: `trigger_reconnect` now prefers `Legion::Data::Connection.reconnect_with_fresh_creds` when available (requires companion PR in legion-data), falls back to existing `sequel.disconnect` + `test_connection` for backward compatibility
- **Callback registry**: New `on_credential_rotation(name, &block)` API lets consumers hook into rotation events — thread-safe via mutex, individually rescued to prevent cascade failures

## Files Changed

| File | Change |
|---|---|
| `lib/legion/crypt/lease_manager.rb` | Smart reconnect logic + callback registry (+37 lines) |
| `spec/legion/lease_manager_spec.rb` | Comprehensive specs for callbacks and reconnection (+123 lines) |

## Companion PR

- **legion-data**: `fix/credential-reconnect` — adds `Connection.reconnect_with_fresh_creds` that this PR calls

## Test plan

- [ ] Vault lease expires → verify `reconnect_with_fresh_creds` is called when legion-data provides it
- [ ] Vault lease expires without legion-data upgrade → verify fallback to `disconnect` + `test_connection`
- [ ] Register multiple `on_credential_rotation` callbacks → verify all fire on rotation
- [ ] One callback raises → verify others still execute
- [ ] Run specs: `bundle exec rspec spec/legion/lease_manager_spec.rb`