### PR TITLE
fix(lease_manager): use reconnect_with_fresh_creds for PG credential rotation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# Standard LegionIO pre-commit configuration
+# Install: pre-commit install
+# Manual:  pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+        exclude: Gemfile\.lock
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: rubocop
+        name: RuboCop (autofix)
+        entry: scripts/pre-commit-rubocop.sh
+        language: script
+        types: [ruby]
+        pass_filenames: true
+
+      - id: ruby-syntax
+        name: Ruby syntax check
+        entry: ruby -c
+        language: system
+        types: [ruby]
+        pass_filenames: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.5.11] - 2026-04-27
+
+### Fixed
+- `LeaseManager#trigger_reconnect` for `:postgresql` now calls `Legion::Data::Connection.reconnect_with_fresh_creds` (legion-data >= 1.6.26) instead of `sequel.disconnect` + `sequel.test_connection` — Sequel bakes credentials into the pool at `Sequel.connect` time, so the old approach reused stale credentials after Vault lease rotation, causing Apollo and other DB-backed services to silently lose access to data
+- Fallback to legacy `disconnect`/`test_connection` path when `reconnect_with_fresh_creds` is not available, with explicit warning about potential stale credentials
+- Reconnect failures now log at `:error` level (was `:warn`) since a failed reconnect means Apollo and DB-backed services are unavailable until the next rotation cycle
+
+
 ## [1.5.10] - 2026-04-19
 
 ### Fixed

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -466,11 +466,7 @@ module Legion
           Legion::Transport::Connection.force_reconnect
           log.info("LeaseManager: triggered transport reconnect after '#{name}' reissue")
         when :postgresql
-          return unless defined?(Legion::Data::Connection) && Legion::Data::Connection.sequel
-
-          Legion::Data::Connection.sequel.disconnect
-          Legion::Data::Connection.sequel.test_connection
-          log.info("LeaseManager: triggered data pool reconnect after '#{name}' reissue")
+          trigger_postgresql_reconnect(name)
         when :redis
           return unless defined?(Legion::Cache)
 
@@ -482,8 +478,31 @@ module Legion
           log.info("LeaseManager: triggered cache reconnect after '#{name}' reissue")
         end
       rescue StandardError => e
-        handle_exception(e, level: :warn, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
-        log.warn("LeaseManager: reconnect for '#{name}' failed: #{e.message}")
+        handle_exception(e, level: :error, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
+        log.error("LeaseManager: reconnect for '#{name}' FAILED: #{e.message} — " \
+                  'services may be unavailable until the next lease rotation')
+      end
+
+      def trigger_postgresql_reconnect(name)
+        return unless defined?(Legion::Data::Connection)
+
+        if Legion::Data::Connection.respond_to?(:reconnect_with_fresh_creds)
+          success = Legion::Data::Connection.reconnect_with_fresh_creds
+          if success
+            log.info("LeaseManager: reconnected data layer with fresh credentials after '#{name}' reissue")
+          else
+            log.error("LeaseManager: FAILED to reconnect data layer after '#{name}' reissue — " \
+                      'Apollo and other DB-backed services may be unavailable')
+          end
+        elsif Legion::Data::Connection.respond_to?(:sequel) && Legion::Data::Connection.sequel
+          log.warn('LeaseManager: legion-data does not support reconnect_with_fresh_creds — ' \
+                   'falling back to pool disconnect (may use stale credentials)')
+          Legion::Data::Connection.sequel.disconnect
+          Legion::Data::Connection.sequel.test_connection
+          log.info("LeaseManager: triggered data pool reconnect after '#{name}' reissue (legacy path)")
+        else
+          log.warn("LeaseManager: no active data connection to reconnect after '#{name}' reissue")
+        end
       end
 
       def running?

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.10'
+    VERSION = '1.5.11'
   end
 end

--- a/scripts/pre-commit-rubocop.sh
+++ b/scripts/pre-commit-rubocop.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run RuboCop with autofix on staged Ruby files.
+# Tries rubocop directly, then bundle exec. If the binary is truly
+# unavailable (exit 127 / crash / Prism conflict), warns and defers
+# to CI. If rubocop runs but reports offenses, fails the commit.
+set -uo pipefail
+
+run_rubocop() {
+  output=$("$@" -A --force-exclusion "${FILES[@]}" 2>&1)
+  rc=$?
+  if [ $rc -eq 0 ] || [ $rc -eq 1 ]; then
+    # rubocop ran successfully: 0 = clean, 1 = offenses found
+    echo "$output"
+    return $rc
+  fi
+  # exit > 1 means rubocop crashed / couldn't load
+  return 2
+}
+
+FILES=("$@")
+
+if run_rubocop rubocop; then
+  exit 0
+elif [ $? -eq 1 ]; then
+  echo "RuboCop found offenses that could not be auto-corrected."
+  exit 1
+fi
+
+if run_rubocop bundle exec rubocop; then
+  exit 0
+elif [ $? -eq 1 ]; then
+  echo "RuboCop found offenses that could not be auto-corrected."
+  exit 1
+fi
+
+echo "⚠  RuboCop not available locally (Prism conflict?) — CI will enforce."
+echo "   Run 'ruby -c' to at least verify syntax."
+ruby -c "$@" 2>&1 || exit 1
+exit 0

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -611,18 +611,45 @@ RSpec.describe Legion::Crypt::LeaseManager do
     end
 
     context 'when name is :postgresql' do
-      it 'disconnects and reconnects the Sequel pool' do
-        sequel_db = double('Sequel::Database')
-        connection_mod = double('Legion::Data::Connection', sequel: sequel_db)
-        stub_const('Legion::Data::Connection', connection_mod)
-        expect(sequel_db).to receive(:disconnect)
-        expect(sequel_db).to receive(:test_connection)
-        manager.send(:trigger_reconnect, :postgresql)
+      context 'when reconnect_with_fresh_creds is available' do
+        it 'calls reconnect_with_fresh_creds' do
+          data_mod = Module.new
+          connection_mod = double('Legion::Data::Connection')
+          stub_const('Legion::Data', data_mod)
+          stub_const('Legion::Data::Connection', connection_mod)
+          allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(true)
+          expect(connection_mod).to receive(:reconnect_with_fresh_creds).and_return(true)
+          manager.send(:trigger_reconnect, :postgresql)
+        end
+
+        it 'logs error when reconnect_with_fresh_creds returns false' do
+          data_mod = Module.new
+          connection_mod = double('Legion::Data::Connection')
+          stub_const('Legion::Data', data_mod)
+          stub_const('Legion::Data::Connection', connection_mod)
+          allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(true)
+          allow(connection_mod).to receive(:reconnect_with_fresh_creds).and_return(false)
+          expect { manager.send(:trigger_reconnect, :postgresql) }.not_to raise_error
+        end
       end
 
-      it 'skips when Data::Connection.sequel is nil' do
-        connection_mod = double('Legion::Data::Connection', sequel: nil)
-        stub_const('Legion::Data::Connection', connection_mod)
+      context 'when reconnect_with_fresh_creds is not available (legacy)' do
+        it 'falls back to disconnect + test_connection' do
+          data_mod = Module.new
+          sequel_db = double('Sequel::Database')
+          connection_mod = double('Legion::Data::Connection')
+          stub_const('Legion::Data', data_mod)
+          stub_const('Legion::Data::Connection', connection_mod)
+          allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(false)
+          allow(connection_mod).to receive(:respond_to?).with(:sequel).and_return(true)
+          allow(connection_mod).to receive(:sequel).and_return(sequel_db)
+          expect(sequel_db).to receive(:disconnect)
+          expect(sequel_db).to receive(:test_connection)
+          manager.send(:trigger_reconnect, :postgresql)
+        end
+      end
+
+      it 'skips when Legion::Data is not defined' do
         expect { manager.send(:trigger_reconnect, :postgresql) }.not_to raise_error
       end
     end


### PR DESCRIPTION
## Problem

`LeaseManager#trigger_reconnect(:postgresql)` called `sequel.disconnect` + `sequel.test_connection` after Vault lease rotation. Sequel bakes credentials into the pool at `Sequel.connect` time — the reconnect silently reused **stale credentials**, causing Apollo and DB-backed services to lose access to data.

Root cause of Apollo knowledge entries silently disappearing every few hours.

## Fix

- Call `Legion::Data::Connection.reconnect_with_fresh_creds` (legion-data >= 1.6.26)
- Fallback to legacy path for older legion-data with explicit warning
- Escalate reconnect failures from `:warn` to `:error`

## Version: 1.5.10 → 1.5.11