### PR TITLE
Improve cipher decrypt diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /tmp/
 /legion/.idea/
 /.idea/
+*.gem
 *.key
 # rspec failure tracking
 .rspec_status

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# Standard LegionIO pre-commit configuration
+# Install: pre-commit install
+# Manual:  pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+        exclude: Gemfile\.lock
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: rubocop
+        name: RuboCop (autofix)
+        entry: scripts/pre-commit-rubocop.sh
+        language: script
+        types: [ruby]
+        pass_filenames: true
+
+      - id: ruby-syntax
+        name: Ruby syntax check
+        entry: ruby -c
+        language: system
+        types: [ruby]
+        pass_filenames: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.5.11] - 2026-04-27
+
+### Fixed
+- Cipher decrypt now validates malformed authenticated, legacy, and keypair ciphertext inputs before Base64/OpenSSL decoding, raising actionable errors that identify missing non-secret fields such as auth tag, IV, or cluster secret instead of generic `unpack1` nil failures.
+- Crypt's logging compatibility helper now preserves full exception backtraces instead of truncating fallback log output to 10 frames.
+
 ## [1.5.10] - 2026-04-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## [Unreleased]
 
-## [1.5.11] - 2026-04-27
+## [1.5.12] - 2026-04-27
 
 ### Fixed
 - `LeaseManager#trigger_reconnect` for `:postgresql` now calls `Legion::Data::Connection.reconnect_with_fresh_creds` (legion-data >= 1.6.26) instead of `sequel.disconnect` + `sequel.test_connection` — Sequel bakes credentials into the pool at `Sequel.connect` time, so the old approach reused stale credentials after Vault lease rotation, causing Apollo and other DB-backed services to silently lose access to data
 - Fallback to legacy `disconnect`/`test_connection` path when `reconnect_with_fresh_creds` is not available, with explicit warning about potential stale credentials
 - Reconnect failures now log at `:error` level (was `:warn`) since a failed reconnect means Apollo and DB-backed services are unavailable until the next rotation cycle
+- Lease shutdown, logging fallback, and SPIFFE socket cleanup paths now emit warnings/debug logs instead of silently swallowing unexpected failures.
+
+## [1.5.11] - 2026-04-27
+
+### Fixed
 - Cipher decrypt now validates malformed authenticated, legacy, and keypair ciphertext inputs before Base64/OpenSSL decoding, raising actionable errors that identify missing non-secret fields such as auth tag, IV, or cluster secret instead of generic `unpack1` nil failures.
 - Crypt's logging compatibility helper now preserves full exception backtraces instead of truncating fallback log output to 10 frames.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.5.11] - 2026-04-27
+
+### Fixed
+- `LeaseManager#trigger_reconnect` for `:postgresql` now calls `Legion::Data::Connection.reconnect_with_fresh_creds` (legion-data >= 1.6.26) instead of `sequel.disconnect` + `sequel.test_connection` — Sequel bakes credentials into the pool at `Sequel.connect` time, so the old approach reused stale credentials after Vault lease rotation, causing Apollo and other DB-backed services to silently lose access to data
+- Fallback to legacy `disconnect`/`test_connection` path when `reconnect_with_fresh_creds` is not available, with explicit warning about potential stale credentials
+- Reconnect failures now log at `:error` level (was `:warn`) since a failed reconnect means Apollo and DB-backed services are unavailable until the next rotation cycle
+
+
 ## [1.5.10] - 2026-04-19
 
 ### Fixed

--- a/lib/legion/crypt/cipher.rb
+++ b/lib/legion/crypt/cipher.rb
@@ -113,6 +113,13 @@ module Legion
 
       def decrypt_authenticated(message, init_vector, secret)
         _, encoded_ciphertext, encoded_auth_tag = message.split(':', 3)
+        validate_authenticated_ciphertext!(
+          encoded_ciphertext: encoded_ciphertext,
+          encoded_auth_tag:   encoded_auth_tag,
+          init_vector:        init_vector,
+          secret:             secret,
+          message:            message
+        )
 
         decipher = OpenSSL::Cipher.new(AUTHENTICATED_CIPHER)
         decipher.decrypt
@@ -123,6 +130,8 @@ module Legion
       end
 
       def decrypt_legacy(message, init_vector, secret)
+        validate_legacy_ciphertext!(message: message, init_vector: init_vector, secret: secret)
+
         decipher = OpenSSL::Cipher.new(LEGACY_CIPHER)
         decipher.decrypt
         decipher.key = secret
@@ -136,11 +145,69 @@ module Legion
 
       def decrypt_oaep_from_keypair(message)
         _, encoded_message = message.split(':', 2)
+        validate_keypair_ciphertext!(encoded_message: encoded_message, message: message, scheme: RSA_OAEP_PREFIX)
+
         private_key.private_decrypt(Base64.strict_decode64(encoded_message), RSA_OAEP_PADDING)
       end
 
       def decrypt_legacy_from_keypair(message)
+        validate_keypair_ciphertext!(encoded_message: message, message: message, scheme: 'legacy')
+
         private_key.private_decrypt(Base64.decode64(message), RSA_LEGACY_PADDING)
+      end
+
+      def validate_authenticated_ciphertext!(encoded_ciphertext:, encoded_auth_tag:, init_vector:, secret:, message:)
+        missing = []
+        missing << 'ciphertext' if blank?(encoded_ciphertext)
+        missing << 'auth_tag' if blank?(encoded_auth_tag)
+        missing << 'iv' if blank?(init_vector)
+        missing << 'cluster_secret' if blank?(secret)
+        return if missing.empty?
+
+        raise ArgumentError, 'invalid authenticated ciphertext: missing ' \
+                             "#{missing.join(', ')} " \
+                             "(scheme=#{AUTHENTICATED_PREFIX} " \
+                             "message_bytes=#{byte_size(message)} " \
+                             "ciphertext_present=#{present?(encoded_ciphertext)} " \
+                             "auth_tag_present=#{present?(encoded_auth_tag)} " \
+                             "iv_present=#{present?(init_vector)} " \
+                             "cluster_secret_present=#{present?(secret)})"
+      end
+
+      def validate_legacy_ciphertext!(message:, init_vector:, secret:)
+        missing = []
+        missing << 'ciphertext' if blank?(message)
+        missing << 'iv' if blank?(init_vector)
+        missing << 'cluster_secret' if blank?(secret)
+        return if missing.empty?
+
+        raise ArgumentError, 'invalid legacy ciphertext: missing ' \
+                             "#{missing.join(', ')} " \
+                             "(message_bytes=#{byte_size(message)} " \
+                             "iv_present=#{present?(init_vector)} " \
+                             "cluster_secret_present=#{present?(secret)})"
+      end
+
+      def validate_keypair_ciphertext!(encoded_message:, message:, scheme:)
+        return unless blank?(encoded_message)
+
+        raise ArgumentError, 'invalid keypair ciphertext: missing ciphertext ' \
+                             "(scheme=#{scheme} message_bytes=#{byte_size(message)})"
+      end
+
+      def blank?(value)
+        value.nil? || (value.respond_to?(:empty?) && value.empty?)
+      end
+
+      def present?(value)
+        !blank?(value)
+      end
+
+      def byte_size(value)
+        return 0 if value.nil?
+        return value.bytesize if value.respond_to?(:bytesize)
+
+        value.to_s.bytesize
       end
     end
   end

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -466,11 +466,7 @@ module Legion
           Legion::Transport::Connection.force_reconnect
           log.info("LeaseManager: triggered transport reconnect after '#{name}' reissue")
         when :postgresql
-          return unless defined?(Legion::Data::Connection) && Legion::Data::Connection.sequel
-
-          Legion::Data::Connection.sequel.disconnect
-          Legion::Data::Connection.sequel.test_connection
-          log.info("LeaseManager: triggered data pool reconnect after '#{name}' reissue")
+          trigger_postgresql_reconnect(name)
         when :redis
           return unless defined?(Legion::Cache)
 
@@ -482,8 +478,31 @@ module Legion
           log.info("LeaseManager: triggered cache reconnect after '#{name}' reissue")
         end
       rescue StandardError => e
-        handle_exception(e, level: :warn, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
-        log.warn("LeaseManager: reconnect for '#{name}' failed: #{e.message}")
+        handle_exception(e, level: :error, operation: 'crypt.lease_manager.trigger_reconnect', lease_name: name)
+        log.error("LeaseManager: reconnect for '#{name}' FAILED: #{e.message} — " \
+                  'services may be unavailable until the next lease rotation')
+      end
+
+      def trigger_postgresql_reconnect(name)
+        return unless defined?(Legion::Data::Connection)
+
+        if Legion::Data::Connection.respond_to?(:reconnect_with_fresh_creds)
+          success = Legion::Data::Connection.reconnect_with_fresh_creds
+          if success
+            log.info("LeaseManager: reconnected data layer with fresh credentials after '#{name}' reissue")
+          else
+            log.error("LeaseManager: FAILED to reconnect data layer after '#{name}' reissue — " \
+                      'Apollo and other DB-backed services may be unavailable')
+          end
+        elsif Legion::Data::Connection.respond_to?(:sequel) && Legion::Data::Connection.sequel
+          log.warn('LeaseManager: legion-data does not support reconnect_with_fresh_creds — ' \
+                   'falling back to pool disconnect (may use stale credentials)')
+          Legion::Data::Connection.sequel.disconnect
+          Legion::Data::Connection.sequel.test_connection
+          log.info("LeaseManager: triggered data pool reconnect after '#{name}' reissue (legacy path)")
+        else
+          log.warn("LeaseManager: no active data connection to reconnect after '#{name}' reissue")
+        end
       end
 
       def running?

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -248,10 +248,10 @@ module Legion
           next if @state_mutex.synchronize { @active_leases.empty? }
 
           Timeout.timeout(10) { shutdown }
-        rescue Timeout::Error
-          warn '[LeaseManager] at_exit shutdown timed out after 10s'
+        rescue Timeout::Error => e
+          log.warn("[LeaseManager] at_exit shutdown timed out after 10s: #{e.message}")
         rescue StandardError => e # best effort on crash
-          warn "[LeaseManager] at_exit shutdown failed: #{e.class}: #{e.message}"
+          log.warn("[LeaseManager] at_exit shutdown failed: #{e.class}: #{e.message}")
         end
         @at_exit_registered = true
       end

--- a/lib/legion/crypt/lease_manager.rb
+++ b/lib/legion/crypt/lease_manager.rb
@@ -250,8 +250,8 @@ module Legion
           Timeout.timeout(10) { shutdown }
         rescue Timeout::Error
           warn '[LeaseManager] at_exit shutdown timed out after 10s'
-        rescue StandardError # best effort on crash
-          nil
+        rescue StandardError => e # best effort on crash
+          warn "[LeaseManager] at_exit shutdown failed: #{e.class}: #{e.message}"
         end
         @at_exit_registered = true
       end
@@ -484,7 +484,10 @@ module Legion
       end
 
       def trigger_postgresql_reconnect(name)
-        return unless defined?(Legion::Data::Connection)
+        unless defined?(Legion::Data::Connection)
+          log.debug("LeaseManager: no Legion::Data::Connection loaded for '#{name}' reconnect")
+          return
+        end
 
         if Legion::Data::Connection.respond_to?(:reconnect_with_fresh_creds)
           success = Legion::Data::Connection.reconnect_with_fresh_creds

--- a/lib/legion/crypt/spiffe/workload_api_client.rb
+++ b/lib/legion/crypt/spiffe/workload_api_client.rb
@@ -104,8 +104,16 @@ module Legion
             send_grpc_request(sock, method_path, request_body)
             read_grpc_response(sock)
           ensure
-            sock.close rescue nil # rubocop:disable Style/RescueModifier
+            close_workload_api_socket(sock, method_path)
           end
+        end
+
+        def close_workload_api_socket(sock, method_path)
+          sock.close
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'crypt.spiffe.workload_api_client.close_socket',
+                           method_path: method_path, socket_path: @socket_path)
+          nil
         end
 
         def connect_socket

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.11'
+    VERSION = '1.5.12'
   end
 end

--- a/lib/legion/crypt/version.rb
+++ b/lib/legion/crypt/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Crypt
-    VERSION = '1.5.10'
+    VERSION = '1.5.11'
   end
 end

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -6,8 +6,8 @@ begin
     'lib/legion/logging/helper.rb'
   )
   require helper_path if File.exist?(helper_path)
-rescue Gem::LoadError
-  nil
+rescue Gem::LoadError => e
+  Kernel.warn("legion-crypt logging helper fallback active: #{e.message}")
 end
 
 require 'legion/logging'
@@ -38,7 +38,8 @@ module Legion
             return false unless Legion.const_defined?('Logging')
 
             Legion::Logging.respond_to?(level)
-          rescue StandardError
+          rescue StandardError => e
+            ::Kernel.warn("legion-crypt logging support check failed: #{e.message}")
             false
           end
         end
@@ -77,7 +78,8 @@ module Legion
         return false unless Legion.const_defined?('Logging')
 
         Legion::Logging.respond_to?(level)
-      rescue StandardError
+      rescue StandardError => e
+        ::Kernel.warn("legion-crypt logging support check failed: #{e.message}")
         false
       end
 

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -7,7 +7,8 @@ begin
   )
   require helper_path if File.exist?(helper_path)
 rescue Gem::LoadError => e
-  Kernel.warn("legion-crypt logging helper fallback active: #{e.message}")
+  require 'legion/logging'
+  Legion::Logging.warn("legion-crypt logging helper fallback active: #{e.message}")
 end
 
 require 'legion/logging'
@@ -39,7 +40,7 @@ module Legion
 
             Legion::Logging.respond_to?(level)
           rescue StandardError => e
-            ::Kernel.warn("legion-crypt logging support check failed: #{e.message}")
+            Legion::Logging.warn("legion-crypt logging support check failed: #{e.message}")
             false
           end
         end
@@ -79,7 +80,7 @@ module Legion
 
         Legion::Logging.respond_to?(level)
       rescue StandardError => e
-        ::Kernel.warn("legion-crypt logging support check failed: #{e.message}")
+        Legion::Logging.warn("legion-crypt logging support check failed: #{e.message}")
         false
       end
 

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -86,7 +86,7 @@ module Legion
         prefix = operation ? "#{operation} failed: " : ''
         details = opts.reject { |key, _value| key.to_s == 'operation' }.map { |key, value| "#{key}=#{value}" }
         detail_suffix = details.empty? ? '' : " (#{details.join(' ')})"
-        backtrace = Array(exception.backtrace).first(10).join("\n")
+        backtrace = Array(exception.backtrace).join("\n")
         base = "#{prefix}#{exception.class}: #{exception.message}#{detail_suffix}"
         return base if backtrace.empty? || level == :debug
         return base if backtrace.empty?

--- a/scripts/pre-commit-rubocop.sh
+++ b/scripts/pre-commit-rubocop.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run RuboCop with autofix on staged Ruby files.
+# Tries rubocop directly, then bundle exec. If the binary is truly
+# unavailable (exit 127 / crash / Prism conflict), warns and defers
+# to CI. If rubocop runs but reports offenses, fails the commit.
+set -uo pipefail
+
+run_rubocop() {
+  output=$("$@" -A --force-exclusion "${FILES[@]}" 2>&1)
+  rc=$?
+  if [ $rc -eq 0 ] || [ $rc -eq 1 ]; then
+    # rubocop ran successfully: 0 = clean, 1 = offenses found
+    echo "$output"
+    return $rc
+  fi
+  # exit > 1 means rubocop crashed / couldn't load
+  return 2
+}
+
+FILES=("$@")
+
+if run_rubocop rubocop; then
+  exit 0
+elif [ $? -eq 1 ]; then
+  echo "RuboCop found offenses that could not be auto-corrected."
+  exit 1
+fi
+
+if run_rubocop bundle exec rubocop; then
+  exit 0
+elif [ $? -eq 1 ]; then
+  echo "RuboCop found offenses that could not be auto-corrected."
+  exit 1
+fi
+
+echo "⚠  RuboCop not available locally (Prism conflict?) — CI will enforce."
+echo "   Run 'ruby -c' to at least verify syntax."
+ruby -c "$@" 2>&1 || exit 1
+exit 0

--- a/scripts/pre-commit-rubocop.sh
+++ b/scripts/pre-commit-rubocop.sh
@@ -13,7 +13,9 @@ run_rubocop() {
     echo "$output"
     return $rc
   fi
-  # exit > 1 means rubocop crashed / couldn't load
+  # exit > 1 means rubocop crashed / couldn't load. Preserve the output so the
+  # local failure is visible even when CI remains the final enforcement point.
+  echo "$output" >&2
   return 2
 }
 

--- a/spec/legion/cipher_spec.rb
+++ b/spec/legion/cipher_spec.rb
@@ -31,6 +31,23 @@ RSpec.describe Legion::Crypt::Cipher do
     end.to raise_error(OpenSSL::Cipher::CipherError)
   end
 
+  it 'raises an actionable error when authenticated ciphertext is missing fields' do
+    message = @crypt.encrypt('foobar')
+    prefix, ciphertext = message[:enciphered_message].split(':', 3)
+
+    expect do
+      @crypt.decrypt("#{prefix}:#{ciphertext}", message[:iv])
+    end.to raise_error(ArgumentError, /invalid authenticated ciphertext: missing auth_tag .*auth_tag_present=false/)
+  end
+
+  it 'raises an actionable error when authenticated ciphertext is missing an iv' do
+    message = @crypt.encrypt('foobar')
+
+    expect do
+      @crypt.decrypt(message[:enciphered_message], nil)
+    end.to raise_error(ArgumentError, /invalid authenticated ciphertext: missing iv .*iv_present=false/)
+  end
+
   it 'can decrypt legacy cbc ciphertext' do
     cipher = OpenSSL::Cipher.new('aes-256-cbc')
     cipher.encrypt

--- a/spec/legion/crypt/spiffe_workload_api_client_spec.rb
+++ b/spec/legion/crypt/spiffe_workload_api_client_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe Legion::Crypt::Spiffe::WorkloadApiClient do
     end
   end
 
+  describe '#close_workload_api_socket' do
+    it 'logs socket close failures' do
+      fake_sock = instance_double(UNIXSocket)
+      close_error = StandardError.new('close failed')
+      allow(fake_sock).to receive(:close).and_raise(close_error)
+
+      expect(client).to receive(:handle_exception).with(
+        close_error,
+        level:       :debug,
+        operation:   'crypt.spiffe.workload_api_client.close_socket',
+        method_path: '/spire.api.agent.X509SVID/FetchX509SVID',
+        socket_path: '/tmp/fake.sock'
+      )
+
+      expect(client.send(:close_workload_api_socket, fake_sock, '/spire.api.agent.X509SVID/FetchX509SVID')).to be_nil
+    end
+  end
+
   describe '#fetch_x509_svid' do
     context 'when the Workload API is unavailable (no socket)' do
       before do

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -649,7 +649,11 @@ RSpec.describe Legion::Crypt::LeaseManager do
         end
       end
 
-      it 'skips when Legion::Data is not defined' do
+      it 'logs when Legion::Data::Connection is not defined' do
+        logger = instance_double(Legion::Logging::Helper::CompatLogger)
+        allow(manager).to receive(:log).and_return(logger)
+        expect(logger).to receive(:debug).with("LeaseManager: no Legion::Data::Connection loaded for 'postgresql' reconnect")
+
         expect { manager.send(:trigger_reconnect, :postgresql) }.not_to raise_error
       end
     end

--- a/spec/legion/lease_manager_spec.rb
+++ b/spec/legion/lease_manager_spec.rb
@@ -611,18 +611,45 @@ RSpec.describe Legion::Crypt::LeaseManager do
     end
 
     context 'when name is :postgresql' do
-      it 'disconnects and reconnects the Sequel pool' do
-        sequel_db = double('Sequel::Database')
-        connection_mod = double('Legion::Data::Connection', sequel: sequel_db)
-        stub_const('Legion::Data::Connection', connection_mod)
-        expect(sequel_db).to receive(:disconnect)
-        expect(sequel_db).to receive(:test_connection)
-        manager.send(:trigger_reconnect, :postgresql)
+      context 'when reconnect_with_fresh_creds is available' do
+        it 'calls reconnect_with_fresh_creds' do
+          data_mod = Module.new
+          connection_mod = double('Legion::Data::Connection')
+          stub_const('Legion::Data', data_mod)
+          stub_const('Legion::Data::Connection', connection_mod)
+          allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(true)
+          expect(connection_mod).to receive(:reconnect_with_fresh_creds).and_return(true)
+          manager.send(:trigger_reconnect, :postgresql)
+        end
+
+        it 'logs error when reconnect_with_fresh_creds returns false' do
+          data_mod = Module.new
+          connection_mod = double('Legion::Data::Connection')
+          stub_const('Legion::Data', data_mod)
+          stub_const('Legion::Data::Connection', connection_mod)
+          allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(true)
+          allow(connection_mod).to receive(:reconnect_with_fresh_creds).and_return(false)
+          expect { manager.send(:trigger_reconnect, :postgresql) }.not_to raise_error
+        end
       end
 
-      it 'skips when Data::Connection.sequel is nil' do
-        connection_mod = double('Legion::Data::Connection', sequel: nil)
-        stub_const('Legion::Data::Connection', connection_mod)
+      context 'when reconnect_with_fresh_creds is not available (legacy)' do
+        it 'falls back to disconnect + test_connection' do
+          data_mod = Module.new
+          sequel_db = double('Sequel::Database')
+          connection_mod = double('Legion::Data::Connection')
+          stub_const('Legion::Data', data_mod)
+          stub_const('Legion::Data::Connection', connection_mod)
+          allow(connection_mod).to receive(:respond_to?).with(:reconnect_with_fresh_creds).and_return(false)
+          allow(connection_mod).to receive(:respond_to?).with(:sequel).and_return(true)
+          allow(connection_mod).to receive(:sequel).and_return(sequel_db)
+          expect(sequel_db).to receive(:disconnect)
+          expect(sequel_db).to receive(:test_connection)
+          manager.send(:trigger_reconnect, :postgresql)
+        end
+      end
+
+      it 'skips when Legion::Data is not defined' do
         expect { manager.send(:trigger_reconnect, :postgresql) }.not_to raise_error
       end
     end


### PR DESCRIPTION
## Summary
- validate malformed authenticated, legacy, and keypair ciphertext before Base64/OpenSSL decoding
- include non-secret presence/shape fields in decrypt errors so missing auth tag, IV, or cluster secret is visible
- preserve full fallback crypt helper backtraces
- bump version to 1.5.11 and update changelog

## Verification
- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- `bundle exec rubocop -A`